### PR TITLE
Phase 1 — Client-side migration & hardening (Tasks 1.1–1.8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,9 @@ COPY templates/ templates/
 COPY static/ static/
 COPY requirements.txt .
 
-# Create uploads directory with proper permissions
-RUN mkdir -p uploads && \
-    chown -R appuser:appuser /app
+# Set permissions for non-root user
+# No uploads directory needed — all log parsing is client-side.
+RUN chown -R appuser:appuser /app
 
 # Switch to non-root user
 USER appuser

--- a/app.py
+++ b/app.py
@@ -1,30 +1,10 @@
-from flask import Flask, render_template, request, jsonify
-import os
-from werkzeug.utils import secure_filename
-import re
+from flask import Flask, render_template, jsonify
 
 app = Flask(__name__)
-app.config['UPLOAD_FOLDER'] = 'uploads'
-app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max file size
 
-# Ensure upload directory exists
-os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
-
-# Regex pattern to extract log category from Unreal Engine log lines.
-# Handles both timestamped and plain formats:
-#   [2024.01.15-10.30.45:123][  0]LogCore: Display: message  (with timestamp)
-#   LogCore: Display: message                                  (without timestamp)
-#
-# Group 1: timestamp string from the first bracket (e.g. "2024.01.15-10.30.45:123"), or None
-# Group 2: log category name (e.g. "LogCore")
-#
-# Uses [^\]]* (any char except ']') instead of .*? for reliable bracket matching.
-LOG_LINE_PATTERN = re.compile(
-    r'(?:\[([^\]]*)\]\s*)?'        # Optional first bracket — captures timestamp (group 1)
-    r'(?:\[[^\]]*\]\s*)*'          # Zero or more additional brackets (frame number, etc.)
-    r'([A-Za-z][A-Za-z0-9_]*)'    # Log category name (group 2)
-    r'\s*:'                        # Colon separator
-)
+# This server's only job is to serve static assets and render index.html.
+# All log parsing happens client-side in the browser — log data never leaves
+# the user's machine. Do not add backend endpoints that receive log content.
 
 @app.route('/')
 def index():
@@ -34,110 +14,7 @@ def index():
 def health():
     return jsonify({'status': 'healthy', 'message': 'Unreal Engine Log Analyzer is running'}), 200
 
-def _parse_log_lines(lines):
-    """Parse an iterable of log lines and return (entries, log_types)."""
-    log_entries = []
-    log_type_counts = {}
-
-    for line in lines:
-        if not line.strip() or ':' not in line:
-            continue
-        match = LOG_LINE_PATTERN.match(line)
-        if match:
-            timestamp = match.group(1)    # e.g. "2024.01.15-10.30.45:123", or None
-            log_category = match.group(2)
-            content_start = match.end()
-            log_type_counts[log_category] = log_type_counts.get(log_category, 0) + 1
-            entry = {
-                'type': log_category,
-                'content': line[content_start:].strip()
-            }
-            if timestamp:
-                entry['timestamp'] = timestamp
-            log_entries.append(entry)
-
-    log_types = [{'type': t, 'count': log_type_counts[t]} for t in sorted(log_type_counts.keys())]
-    return log_entries, log_types
-
-
-@app.route('/upload', methods=['POST'])
-def upload_file():
-    if 'file' not in request.files:
-        return jsonify({'error': 'No file part'}), 400
-    
-    file = request.files['file']
-    if file.filename == '':
-        return jsonify({'error': 'No selected file'}), 400
-    
-    if file:
-        filename = secure_filename(file.filename)
-        filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
-        file.save(filepath)
-        
-        with open(filepath, 'r', encoding='utf-8') as f:
-            log_entries, log_types = _parse_log_lines(f)
-
-        return jsonify({
-            'entries': log_entries,
-            'log_types': log_types
-        })
-
-
-@app.route('/paste', methods=['POST'])
-def paste_log():
-    data = request.get_json()
-    if not data or 'text' not in data:
-        return jsonify({'error': 'No log text provided'}), 400
-
-    text = data['text']
-    if not text.strip():
-        return jsonify({'error': 'Log text is empty'}), 400
-
-    lines = text.splitlines()
-    log_entries, log_types = _parse_log_lines(lines)
-
-    return jsonify({
-        'entries': log_entries,
-        'log_types': log_types
-    })
-
-@app.route('/filter', methods=['POST'])
-def filter_logs():
-    data = request.get_json()
-    selected_types = data.get('types', [])
-    
-    # Read the log file again
-    filename = data.get('filename')
-    if not filename:
-        return jsonify({'error': 'No filename provided'}), 400
-    
-    filepath = os.path.join(app.config['UPLOAD_FOLDER'], secure_filename(filename))
-    
-    if not os.path.exists(filepath):
-        return jsonify({'error': 'File not found'}), 404
-    
-    filtered_entries = []
-    with open(filepath, 'r', encoding='utf-8') as f:
-        for line in f:
-            if not line.strip() or ':' not in line:
-                continue
-            match = LOG_LINE_PATTERN.match(line)
-            if match:
-                timestamp = match.group(1)
-                log_category = match.group(2)
-                content_start = match.end()
-                if not selected_types or log_category in selected_types:
-                    entry = {
-                        'type': log_category,
-                        'content': line[content_start:].strip()
-                    }
-                    if timestamp:
-                        entry['timestamp'] = timestamp
-                    filtered_entries.append(entry)
-    
-    return jsonify({'entries': filtered_entries})
-
 if __name__ == '__main__':
-    # Get port from Railway environment variable
+    import os
     port = int(os.environ.get('PORT', 5000))
-    app.run(host='0.0.0.0', port=port, debug=False) 
+    app.run(host='0.0.0.0', port=port, debug=False)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,8 +8,6 @@ services:
     environment:
       - FLASK_ENV=production
       - PORT=8080
-    volumes:
-      - uploads_data:/app/uploads
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8080/health', timeout=5)"]
@@ -17,7 +15,3 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-
-volumes:
-  uploads_data:
-    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,6 @@ services:
     environment:
       - FLASK_ENV=production
       - PORT=8080
-    volumes:
-      # Mount uploads directory for persistent file storage
-      - uploads_data:/app/uploads
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8080/health', timeout=5)"]
@@ -34,11 +31,6 @@ services:
       - PORT=5000
     volumes:
       - .:/app
-      - uploads_data:/app/uploads
     restart: unless-stopped
     profiles:
       - dev
-
-volumes:
-  uploads_data:
-    driver: local

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,61 +1,6 @@
-// API communication module
-class API {
-    // Upload log file
-    static async uploadFile(file) {
-        const formData = new FormData();
-        formData.append('file', file);
-        
-        const response = await Utils.handleApiCall(
-            () => fetch('/upload', { method: 'POST', body: formData }),
-            'Failed to upload file. Please try again.'
-        );
-        
-        if (!response.ok) {
-            const data = await response.json();
-            throw new Error(data.error || 'Error uploading file');
-        }
-        
-        return await response.json();
-    }
-
-    // Analyze pasted log text (no file upload needed)
-    static async pasteLog(text) {
-        const response = await Utils.handleApiCall(
-            () => fetch('/paste', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ text })
-            }),
-            'Failed to analyze pasted log. Please try again.'
-        );
-        
-        if (!response.ok) {
-            const data = await response.json();
-            throw new Error(data.error || 'Error analyzing pasted log');
-        }
-        
-        return await response.json();
-    }
-
-    // Filter logs by type
-    static async filterLogs(filename, types) {
-        const response = await Utils.handleApiCall(
-            () => fetch('/filter', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ filename, types })
-            }),
-            'Failed to filter logs. Please try again.'
-        );
-        
-        if (!response.ok) {
-            const data = await response.json();
-            throw new Error(data.error || 'Error filtering logs');
-        }
-        
-        return await response.json();
-    }
-}
-
-// Export for use in other modules
-window.API = API;
+// api.js — REMOVED
+//
+// This module previously handled /upload, /paste, and /filter server endpoints.
+// All log parsing is now done client-side in log-parser.js (LogParser.parseLogLines).
+// Log data never leaves the browser. This file is kept as a placeholder so that
+// any external references do not 404, but it exports nothing.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,4 +1,4 @@
-// Main application module - VERSION 1.5
+// Main application module - VERSION 1.6
 
 class LogAnalyzerApp {
     constructor() {
@@ -448,6 +448,26 @@ class LogAnalyzerApp {
                 reader.readAsText(file);
             });
 
+            // Validate: reject empty files.
+            if (text.trim().length === 0) {
+                throw new Error('File is empty.');
+            }
+
+            // Validate: reject binary-looking content.
+            // Sample first 4 KB; allow tab (9), LF (10), VT (11), FF (12), CR (13).
+            // Null bytes and other low control chars strongly suggest binary data.
+            const sampleSize = Math.min(text.length, 4096);
+            let nonPrintable = 0;
+            for (let i = 0; i < sampleSize; i++) {
+                const code = text.charCodeAt(i);
+                if (code === 0 || code < 9 || (code > 13 && code < 32)) {
+                    nonPrintable++;
+                }
+            }
+            if (nonPrintable / sampleSize > 0.1) {
+                throw new Error('File does not appear to be a text log file (binary content detected).');
+            }
+
             const data = LogParser.parseLogLines(text);
 
             // First, update the data state
@@ -584,6 +604,13 @@ class LogAnalyzerApp {
     handleSearchChange() {
         const searchTerm = this.ui.getSearchTerm();
         const searchOptions = this.ui.getSearchOptions();
+
+        // Regex DoS guard — reject patterns longer than 200 chars.
+        if (searchOptions.useRegex && searchTerm.length > 200) {
+            Utils.showErrorToast('Regex pattern too long — maximum is 200 characters.');
+            return;
+        }
+
         this.appState.updateFilters({ 
             search: searchTerm,
             caseSensitive: searchOptions.caseSensitive,
@@ -612,8 +639,26 @@ class LogAnalyzerApp {
     // Update display based on current state
     updateDisplay() {
         const state = this.appState.getState();
-        const filteredEntries = this.appState.getFilteredEntries();
-        
+
+        // Time regex searches and warn if slow (>300 ms) — part of DoS mitigation.
+        // Synchronous regex on large logs can block the main thread; surfacing the
+        // timing nudges users toward more specific patterns. Web Worker search
+        // (Task 2.4) will eliminate this entirely once implemented.
+        let filteredEntries;
+        if (state.filters.useRegex && state.filters.search) {
+            const t0 = performance.now();
+            filteredEntries = this.appState.getFilteredEntries();
+            const elapsed = performance.now() - t0;
+            if (elapsed > 300) {
+                Utils.showInfoToast(
+                    `Regex search took ${Math.round(elapsed)} ms — try a more specific pattern.`,
+                    'Slow search'
+                );
+            }
+        } else {
+            filteredEntries = this.appState.getFilteredEntries();
+        }
+
         // Update UI
         this.ui.displayLogEntries(filteredEntries);
         this.ui.updateLogLevelCounts(filteredEntries);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,4 +1,4 @@
-// Main application module - VERSION 1.3
+// Main application module - VERSION 1.5
 
 class LogAnalyzerApp {
     constructor() {
@@ -415,12 +415,19 @@ class LogAnalyzerApp {
         return memreportIndicators.some(pattern => pattern.test(content));
     }
 
-    // Handle log file upload
+    // Handle log file upload — reads file in the browser, no server upload.
     async handleLogFileUpload() {
         const file = this.ui.elements.logFile.files[0];
         
         if (!file) {
             Utils.showErrorToast('Please select a file');
+            return;
+        }
+
+        // Client-side size guard — reject files over 100 MB before reading.
+        const MAX_LOG_SIZE = 100 * 1024 * 1024;
+        if (file.size > MAX_LOG_SIZE) {
+            Utils.showErrorToast('File too large — maximum is 100 MB.');
             return;
         }
 
@@ -432,23 +439,33 @@ class LogAnalyzerApp {
         this.appState.pauseSubscriptions();
 
         try {
-            const data = await API.uploadFile(file);
-            
+            // Read the file entirely in the browser — no upload to server.
+            const text = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = (e) => resolve(e.target.result);
+                reader.onerror = () => reject(new Error('Failed to read file'));
+                reader.onabort = () => reject(new Error('File reading was aborted'));
+                reader.readAsText(file);
+            });
+
+            const data = LogParser.parseLogLines(text);
+
             // First, update the data state
             this.appState.update({
                 currentFile: file.name,
                 allEntries: data.entries,
-                logTypes: data.log_types
+                logTypes: data.logTypes
             });
             
             // Update UI
-            this.ui.createLogTypeFilters(data.log_types);
+            this.ui.createLogTypeFilters(data.logTypes);
             
             // Update display directly
             this.updateDisplay();
             
         } catch (error) {
-            // Error already handled by API module
+            Utils.showErrorToast('Failed to read file: ' + error.message);
+            console.error('File read error:', error);
         } finally {
             // Reset UI state
             this.ui.updateButtonText('Refresh');
@@ -521,7 +538,7 @@ class LogAnalyzerApp {
         return this.handleLogFileUpload();
     }
 
-    // Handle paste log analysis
+    // Handle paste log analysis — parses in the browser, no server round-trip.
     async handlePasteAnalyze() {
         const textarea = document.getElementById('pasteLogText');
         const text = textarea ? textarea.value : '';
@@ -540,18 +557,20 @@ class LogAnalyzerApp {
         this.appState.pauseSubscriptions();
 
         try {
-            const data = await API.pasteLog(text);
+            // Parse entirely in the browser — no server round-trip.
+            const data = LogParser.parseLogLines(text);
 
             this.appState.update({
                 currentFile: 'pasted-log',
                 allEntries: data.entries,
-                logTypes: data.log_types
+                logTypes: data.logTypes
             });
 
-            this.ui.createLogTypeFilters(data.log_types);
+            this.ui.createLogTypeFilters(data.logTypes);
             this.updateDisplay();
         } catch (error) {
-            // Error already handled by API module
+            Utils.showErrorToast('Failed to parse log: ' + error.message);
+            console.error('Parse error:', error);
         } finally {
             if (analyzeButton) {
                 analyzeButton.textContent = 'Analyze';
@@ -616,4 +635,4 @@ if (document.readyState === 'loading') {
     setTimeout(() => {
         window.app = LogAnalyzerApp.init();
     }, 100);
-} 
+}

--- a/static/js/log-parser.js
+++ b/static/js/log-parser.js
@@ -1,0 +1,77 @@
+// log-parser.js — client-side Unreal Engine log parser
+// Mirrors the regex and logic that previously lived in Python _parse_log_lines().
+// Log data never leaves the browser; this module does all parsing locally.
+
+// Regex pattern to extract log category from Unreal Engine log lines.
+// Handles both timestamped and plain formats:
+//   [2024.01.15-10.30.45:123][  0]LogCore: Display: message  (with timestamp)
+//   LogCore: Display: message                                  (without timestamp)
+//
+// Group 1: timestamp string from the first bracket (e.g. "2024.01.15-10.30.45:123"), or undefined
+// Group 2: log category name (e.g. "LogCore")
+//
+// Uses [^\]]* (any char except ']') instead of .*? for reliable bracket matching.
+const LOG_LINE_PATTERN = /^(?:\[([^\]]*)\]\s*)?(?:\[[^\]]*\]\s*)*([A-Za-z][A-Za-z0-9_]*)\s*:/;
+
+/**
+ * Parse Unreal Engine log text into structured entries.
+ *
+ * Non-matching lines that follow a matched entry are treated as continuation
+ * lines (e.g. callstack frames from a Fatal error) and appended to the
+ * previous entry's content with a '\n' separator.  This allows the full
+ * callstack to live on a single entry so it can be rendered with preserved
+ * line breaks (white-space: pre-wrap).
+ *
+ * @param {string} text - Raw log file content (full text, not pre-split)
+ * @returns {{ entries: Array<{type: string, content: string, timestamp?: string}>,
+ *             logTypes: Array<{type: string, count: number}> }}
+ */
+function parseLogLines(text) {
+    const lines = text.split('\n');
+    const entries = [];
+    const logTypeCounts = {};
+
+    for (const rawLine of lines) {
+        // trimEnd: keep any leading whitespace (indented callstack lines) but
+        // strip trailing \r on Windows line endings.
+        const line = rawLine.trimEnd();
+
+        if (!line.trim()) {
+            // Blank line — not a log entry and not useful as a continuation.
+            continue;
+        }
+
+        const match = LOG_LINE_PATTERN.exec(line);
+
+        if (match) {
+            const timestamp = match[1] !== undefined ? match[1] : undefined;
+            const logCategory = match[2];
+            const contentStart = match[0].length;
+            logTypeCounts[logCategory] = (logTypeCounts[logCategory] || 0) + 1;
+            const entry = {
+                type: logCategory,
+                content: line.slice(contentStart).trim()
+            };
+            if (timestamp !== undefined) {
+                entry.timestamp = timestamp;
+            }
+            entries.push(entry);
+        } else if (entries.length > 0) {
+            // Continuation line (e.g. a callstack frame after "Fatal error:").
+            // Append to the most recent entry so the full stack is one unit.
+            entries[entries.length - 1].content += '\n' + line;
+        }
+        // Lines before the first matched entry that don't match are dropped —
+        // they're typically file headers or blank preamble.
+    }
+
+    // Sort log types alphabetically, matching the old backend behaviour.
+    const logTypes = Object.keys(logTypeCounts)
+        .sort()
+        .map(t => ({ type: t, count: logTypeCounts[t] }));
+
+    return { entries, logTypes };
+}
+
+// Expose for app.js and any inline test harnesses.
+window.LogParser = { parseLogLines };

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,4 +1,4 @@
-// UI management and rendering - VERSION 1.3
+// UI management and rendering - VERSION 1.5
 
 class UI {
     constructor() {
@@ -173,7 +173,7 @@ class UI {
                 div.appendChild(Utils.createTextNode(' '));
                 const badge = Utils.createElement('span', 'badge log-duplicate-badge');
                 badge.title = `${entry.duplicateCount} occurrences`;
-                badge.textContent = `×${entry.duplicateCount}`;
+                badge.textContent = `\u00d7${entry.duplicateCount}`;
                 div.appendChild(badge);
             }
 
@@ -372,7 +372,7 @@ class UI {
     }
 
     exportToJson() {
-tml const entries = window.app.appState.getFilteredEntries();
+        const entries = window.app.appState.getFilteredEntries();
         const jsonContent = JSON.stringify(entries, null, 2);
         this.downloadFile(jsonContent, 'log_entries.json', 'application/json');
     }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -160,6 +160,9 @@ class UI {
 
             const contentSpan = Utils.createElement('span', levelClass);
             contentSpan.textContent = entry.content;
+            // pre-wrap so multi-line continuation content (e.g. callstacks) renders
+            // with preserved line breaks rather than collapsing to one long line.
+            contentSpan.style.whiteSpace = 'pre-wrap';
 
             div.appendChild(typeSpan);
             div.appendChild(Utils.createTextNode(' '));
@@ -369,7 +372,7 @@ class UI {
     }
 
     exportToJson() {
-        const entries = window.app.appState.getFilteredEntries();
+tml const entries = window.app.appState.getFilteredEntries();
         const jsonContent = JSON.stringify(entries, null, 2);
         this.downloadFile(jsonContent, 'log_entries.json', 'application/json');
     }
@@ -526,4 +529,4 @@ class UI {
 }
 
 // Export for use in other modules
-window.UI = UI; 
+window.UI = UI;

--- a/templates/index.html
+++ b/templates/index.html
@@ -629,11 +629,12 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/static/js/state.js?v=1.3"></script>
     <script src="/static/js/utils.js?v=1.3"></script>
-    <script src="/static/js/ui.js?v=1.3"></script>
+    <script src="/static/js/log-parser.js?v=1.4"></script>
+    <script src="/static/js/ui.js?v=1.4"></script>
     <script src="/static/js/api.js?v=1.3"></script>
     <script src="/static/js/memreport-parser.js?v=1.3"></script>
     <script src="/static/js/memreport-charts.js?v=1.3"></script>
     <script src="/static/js/memreport-page.js?v=1.3"></script>
-    <script src="/static/js/app.js?v=1.3"></script>
+    <script src="/static/js/app.js?v=1.4"></script>
 </body>
-</html> 
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -629,12 +629,11 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/static/js/state.js?v=1.3"></script>
     <script src="/static/js/utils.js?v=1.3"></script>
-    <script src="/static/js/log-parser.js?v=1.4"></script>
-    <script src="/static/js/ui.js?v=1.4"></script>
-    <script src="/static/js/api.js?v=1.3"></script>
+    <script src="/static/js/log-parser.js?v=1.5"></script>
+    <script src="/static/js/ui.js?v=1.5"></script>
     <script src="/static/js/memreport-parser.js?v=1.3"></script>
     <script src="/static/js/memreport-charts.js?v=1.3"></script>
     <script src="/static/js/memreport-page.js?v=1.3"></script>
-    <script src="/static/js/app.js?v=1.4"></script>
+    <script src="/static/js/app.js?v=1.5"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Completes all Phase 1 tasks from PLAN.md. UELA is now a 100% client-side application — **log data never leaves the browser**.

---

### Task 1.1 — Delete log-receiving endpoints
- Stripped `app.py` from 143 lines to ~18. Removed `/upload`, `/paste`, `/filter` routes, `UPLOAD_FOLDER`, `os.makedirs`, `secure_filename`, `re`, `LOG_LINE_PATTERN`, `_parse_log_lines`.
- Removed `uploads_data` volume mounts from `docker-compose.yml` and `docker-compose.prod.yml`.
- Removed `uploads/` from `.dockerignore`.

### Task 1.2 — Port log parsing to JavaScript
- Created `static/js/log-parser.js` with `parseLogLines(text)` → `{entries, logTypes}`.
- Regex ported exactly from Python including timestamp/category capture groups.

### Task 1.3 — Replace network uploads with FileReader
- `handleLogFileUpload()` uses `FileReader.readAsText` → `LogParser.parseLogLines`.
- `handlePasteAnalyze()` calls `LogParser.parseLogLines` directly — no fetch.
- `api.js` replaced with a tombstone comment; its `<script>` tag removed from `index.html`.
- Zero POST requests after initial page load.

### Task 1.4 — Simplify server footprint
- Removed `mkdir -p uploads` from `Dockerfile` (no uploads directory needed).
- `app.py` is 18 lines; only `/` and `/health` routes remain.

### Task 1.5 — Client-side parse error handling
- 100 MB size guard before reading.
- `FileReader` `onerror` / `onabort` surface as error toasts.
- Empty-file detection; binary content detection (>10% non-printable chars in first 4 KB → rejected with toast).

### Task 1.6 — Multi-line log entry grouping
- Non-matching lines (callstack frames, etc.) appended to previous entry's `content` with `\n`.
- `white-space: pre-wrap` on content spans so callstacks render readably.

### Task 1.7 — Regex DoS mitigation
- `handleSearchChange()` rejects regex patterns >200 chars with an error toast.
- `updateDisplay()` times regex searches; shows info toast if >300 ms.

### Task 1.8 — Pin requirements.txt
- Already pinned (`Flask==3.0.2`, `Werkzeug==3.0.1`, `gunicorn==21.2.0`). No action needed.

---

**Acceptance check:** After merge, open https://uela.app/, open DevTools → Network, upload a `.log` file. Only the initial page-load requests appear — no `/upload`, `/paste`, or `/filter` requests.