### PR TITLE
feat(phase2.1): crash-first view panel

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,129 +1,68 @@
-// Main application module - VERSION 1.6
+// Main application module - VERSION 1.7
 
 class LogAnalyzerApp {
     constructor() {
         this.appState = new AppState();
         this.ui = new UI();
-        
-        // Route management
-        this.routes = {
-            'log': 'log-panel',
-            'memreport': 'memreport-panel'
-        };
+        this.routes = { 'log': 'log-panel', 'memreport': 'memreport-panel' };
         this.currentRoute = 'log';
-        
-        // MemReport page instance (initialized lazily)
         this.memreportPage = null;
-        
-        // Initialize UI first, then setup event listeners
         this.initializeApp();
     }
 
-    // Initialize the application
     initializeApp() {
-        // Try to initialize UI
         this.ui.initialize();
-        
-        // Setup event listeners and state subscriptions
         this.setupEventListeners();
         this.setupStateSubscriptions();
     }
 
-    // Setup event listeners
     setupEventListeners() {
-        // Tab navigation
         const logTab = document.getElementById('log-tab');
         const memreportTab = document.getElementById('memreport-tab');
-        
-        if (logTab) {
-            logTab.addEventListener('click', () => {
-                this.switchRoute('log');
-            });
-        }
-        
-        if (memreportTab) {
-            memreportTab.addEventListener('click', () => {
-                this.switchRoute('memreport');
-            });
-        }
+        if (logTab) logTab.addEventListener('click', () => this.switchRoute('log'));
+        if (memreportTab) memreportTab.addEventListener('click', () => this.switchRoute('memreport'));
 
-        // File upload for log analyzer
         if (this.ui.elements.uploadForm) {
-            this.ui.elements.uploadForm.addEventListener('submit', (e) => {
-                e.preventDefault();
-                this.handleFileUpload();
-            });
+            this.ui.elements.uploadForm.addEventListener('submit', (e) => { e.preventDefault(); this.handleFileUpload(); });
         }
-
-        // Paste log form
         const pasteForm = document.getElementById('pasteForm');
-        if (pasteForm) {
-            pasteForm.addEventListener('submit', (e) => {
-                e.preventDefault();
-                this.handlePasteAnalyze();
-            });
-        }
+        if (pasteForm) pasteForm.addEventListener('submit', (e) => { e.preventDefault(); this.handlePasteAnalyze(); });
 
         const pasteClearButton = document.getElementById('pasteClearButton');
-        if (pasteClearButton) {
-            pasteClearButton.addEventListener('click', () => {
-                const textarea = document.getElementById('pasteLogText');
-                if (textarea) textarea.value = '';
-            });
-        }
+        if (pasteClearButton) pasteClearButton.addEventListener('click', () => {
+            const textarea = document.getElementById('pasteLogText');
+            if (textarea) textarea.value = '';
+        });
 
         if (this.ui.elements.logFile) {
             this.ui.elements.logFile.addEventListener('change', async () => {
-                if (this.ui.elements.logFile.files.length > 0) {
+                if (this.ui.elements.logFile.files.length > 0)
                     await this.handleFileSelection(this.ui.elements.logFile.files[0]);
-                }
             });
         }
 
-        // File upload for memreport analyzer
         const memreportUploadForm = document.getElementById('memreportUploadForm');
         const memreportFile = document.getElementById('memreportFile');
-        
         if (memreportUploadForm) {
-            memreportUploadForm.addEventListener('submit', (e) => {
-                e.preventDefault();
-                this.handleMemReportFileUpload();
-            });
+            memreportUploadForm.addEventListener('submit', (e) => { e.preventDefault(); this.handleMemReportFileUpload(); });
         }
-
         if (memreportFile) {
             memreportFile.addEventListener('change', async () => {
-                if (memreportFile.files.length > 0) {
+                if (memreportFile.files.length > 0)
                     await this.handleFileSelection(memreportFile.files[0]);
-                }
             });
         }
 
-        // Setup drag and drop for both zones
         this.setupDragAndDrop();
 
-        // Search input with debouncing
         if (this.ui.elements.logSearchInput) {
-            const debouncedSearch = Utils.debounce(() => {
-                this.handleSearchChange();
-            }, 300);
-
+            const debouncedSearch = Utils.debounce(() => this.handleSearchChange(), 300);
             this.ui.elements.logSearchInput.addEventListener('input', debouncedSearch);
         }
-
-        // Advanced search options
-        if (this.ui.elements.caseSensitive) {
-            this.ui.elements.caseSensitive.addEventListener('change', () => {
-                this.handleSearchOptionsChange();
-            });
-        }
-
-        if (this.ui.elements.useRegex) {
-            this.ui.elements.useRegex.addEventListener('change', () => {
-                this.handleSearchOptionsChange();
-            });
-        }
-
+        if (this.ui.elements.caseSensitive)
+            this.ui.elements.caseSensitive.addEventListener('change', () => this.handleSearchOptionsChange());
+        if (this.ui.elements.useRegex)
+            this.ui.elements.useRegex.addEventListener('change', () => this.handleSearchOptionsChange());
         if (this.ui.elements.collapseDuplicates) {
             this.ui.elements.collapseDuplicates.addEventListener('change', () => {
                 this.appState.updateFilters({ collapseDuplicates: this.ui.getCollapseDuplicates() });
@@ -131,209 +70,93 @@ class LogAnalyzerApp {
             });
         }
 
-        // Log level filters
-        const levelFilters = document.querySelectorAll('.log-level-filter');
-        if (levelFilters.length > 0) {
-            levelFilters.forEach(cb => {
-                cb.addEventListener('change', () => {
-                    this.handleLevelFilterChange();
-                });
-            });
-        }
+        document.querySelectorAll('.log-level-filter').forEach(cb => {
+            cb.addEventListener('change', () => this.handleLevelFilterChange());
+        });
 
-        // Copy button
-        if (this.ui.elements.copyButton) {
-            this.ui.elements.copyButton.addEventListener('click', () => {
-                this.ui.copyFilteredResults();
-            });
-        }
-
-        // Export buttons
-        if (this.ui.elements.exportCsv) {
-            this.ui.elements.exportCsv.addEventListener('click', () => {
-                this.ui.exportToCsv();
-            });
-        }
-
-        if (this.ui.elements.exportJson) {
-            this.ui.elements.exportJson.addEventListener('click', () => {
-                this.ui.exportToJson();
-            });
-        }
+        if (this.ui.elements.copyButton)
+            this.ui.elements.copyButton.addEventListener('click', () => this.ui.copyFilteredResults());
+        if (this.ui.elements.exportCsv)
+            this.ui.elements.exportCsv.addEventListener('click', () => this.ui.exportToCsv());
+        if (this.ui.elements.exportJson)
+            this.ui.elements.exportJson.addEventListener('click', () => this.ui.exportToJson());
     }
 
-    // Setup drag and drop for both file input zones
     setupDragAndDrop() {
         const dropZones = [
             { element: document.getElementById('dropZone'), input: document.getElementById('logFile') },
             { element: document.getElementById('memreportDropZone'), input: document.getElementById('memreportFile') }
         ];
-
         dropZones.forEach(({ element, input }) => {
             if (!element || !input) return;
-
-            // Prevent default drag behaviors
-            ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
-                element.addEventListener(eventName, (e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                });
-            });
-
-            // Highlight drop zone when item is dragged over it
-            ['dragenter', 'dragover'].forEach(eventName => {
-                element.addEventListener(eventName, () => {
-                    element.classList.add('drag-over');
-                });
-            });
-
-            ['dragleave', 'drop'].forEach(eventName => {
-                element.addEventListener(eventName, () => {
-                    element.classList.remove('drag-over');
-                });
-            });
-
-            // Handle dropped files
+            ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(ev =>
+                element.addEventListener(ev, (e) => { e.preventDefault(); e.stopPropagation(); })
+            );
+            ['dragenter', 'dragover'].forEach(ev => element.addEventListener(ev, () => element.classList.add('drag-over')));
+            ['dragleave', 'drop'].forEach(ev => element.addEventListener(ev, () => element.classList.remove('drag-over')));
             element.addEventListener('drop', async (e) => {
                 const files = e.dataTransfer.files;
                 if (files.length > 0) {
-                    const dt = new DataTransfer();
-                    dt.items.add(files[0]);
-                    input.files = dt.files;
+                    const dt = new DataTransfer(); dt.items.add(files[0]); input.files = dt.files;
                     await this.handleFileSelection(files[0]);
                 }
             });
-
-            // Handle click to browse
-            element.addEventListener('click', () => {
-                input.click();
-            });
-
-            // Handle keyboard navigation
+            element.addEventListener('click', () => input.click());
             element.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    input.click();
-                }
+                if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); input.click(); }
             });
         });
     }
 
-    // Setup state subscriptions
     setupStateSubscriptions() {
-        this.appState.subscribe((state) => {
-            this.handleStateChange(state);
-        });
+        this.appState.subscribe((state) => this.handleStateChange(state));
     }
 
-    // Handle state change
     handleStateChange(state) {
-        // Update display when state changes (but no loading state management)
-        if (state.allEntries.length > 0) {
-            this.updateDisplay();
-        }
+        if (state.allEntries.length > 0) this.updateDisplay();
     }
 
-    // Switch between routes
     switchRoute(route) {
         if (this.routes[route] && this.currentRoute !== route) {
             const previousRoute = this.currentRoute;
             this.currentRoute = route;
             this.appState.setCurrentRoute(route);
-            
-            // Perform cleanup when switching away from routes
             this.performRouteCleanup(previousRoute);
-            
-            // Update tab visibility using Bootstrap
             const tabTrigger = document.querySelector(`#${route}-tab`);
-            if (tabTrigger) {
-                const tab = new bootstrap.Tab(tabTrigger);
-                tab.show();
-            }
-            
-            // Initialize route-specific components if needed
+            if (tabTrigger) new bootstrap.Tab(tabTrigger).show();
             this.initializeRouteComponents(route);
         }
     }
 
-    // Perform cleanup when switching away from a route
     performRouteCleanup(route) {
-        switch (route) {
-            case 'memreport':
-                // Clear any active charts or heavy DOM elements
-                if (this.memreportPage) {
-                    const memreportContent = document.getElementById('memreportContent');
-                    if (memreportContent) {
-                        // Clean up any charts or heavy elements
-                        this.memreportPage.cleanupCharts(memreportContent);
-                        
-                        // Clear content to free memory
-                        memreportContent.innerHTML = '';
-                    }
-                }
-                break;
-            case 'log':
-                // Clear log-specific state if needed
-                const logContent = document.getElementById('logContent');
-                if (logContent) {
-                    // Clear any heavy log content when switching away
-                    const entries = logContent.querySelectorAll('.log-entry');
-                    if (entries.length > 1000) {
-                        // Only clear if there are many entries to free memory
-                        logContent.innerHTML = '';
-                    }
-                }
-                break;
+        if (route === 'memreport' && this.memreportPage) {
+            const mc = document.getElementById('memreportContent');
+            if (mc) { this.memreportPage.cleanupCharts(mc); mc.innerHTML = ''; }
+        } else if (route === 'log') {
+            const lc = document.getElementById('logContent');
+            if (lc && lc.querySelectorAll('.log-entry').length > 1000) lc.innerHTML = '';
         }
     }
 
-    // Initialize route-specific components
     initializeRouteComponents(route) {
-        switch (route) {
-            case 'memreport':
-                // Initialize MemReport page if not already done
-                if (!this.memreportPage) {
-                    this.memreportPage = new MemReportPage(this.appState, this.ui, Utils);
-                    this.memreportPage.initialize();
-                }
-                break;
-            case 'log':
-                // Log analyzer is always initialized
-                break;
+        if (route === 'memreport' && !this.memreportPage) {
+            this.memreportPage = new MemReportPage(this.appState, this.ui, Utils);
+            this.memreportPage.initialize();
         }
     }
 
-    // Handle file selection and route to appropriate analyzer
     async handleFileSelection(file) {
-        if (!file) {
-            Utils.showErrorToast('Please select a file');
-            return;
-        }
-
+        if (!file) { Utils.showErrorToast('Please select a file'); return; }
         try {
-            // Use enhanced file type detection with content analysis
             const fileType = await this.detectFileTypeWithContent(file);
-            
             if (fileType === 'memreport') {
                 this.switchRoute('memreport');
-                // Set the file in the memreport input and trigger upload
-                const memreportFile = document.getElementById('memreportFile');
-                if (memreportFile) {
-                    // Create a new FileList-like object
-                    const dt = new DataTransfer();
-                    dt.items.add(file);
-                    memreportFile.files = dt.files;
-                    await this.handleMemReportFileUpload();
-                }
+                const mf = document.getElementById('memreportFile');
+                if (mf) { const dt = new DataTransfer(); dt.items.add(file); mf.files = dt.files; await this.handleMemReportFileUpload(); }
             } else {
                 this.switchRoute('log');
-                // Set the file in the log input
-                const logFile = document.getElementById('logFile');
-                if (logFile) {
-                    const dt = new DataTransfer();
-                    dt.items.add(file);
-                    logFile.files = dt.files;
-                }
+                const lf = document.getElementById('logFile');
+                if (lf) { const dt = new DataTransfer(); dt.items.add(file); lf.files = dt.files; }
                 await this.handleLogFileUpload();
             }
         } catch (error) {
@@ -342,66 +165,29 @@ class LogAnalyzerApp {
         }
     }
 
-    // Detect file type based on extension and content
-    detectFileType(file) {
-        const fileName = file.name.toLowerCase();
-        
-        // Check file extension first
-        if (fileName.endsWith('.memreport')) {
-            return 'memreport';
-        }
-        
-        // For .txt files, we need to check content to determine if it's a memreport
-        if (fileName.endsWith('.txt')) {
-            // For now, we'll assume .txt files are logs and let the user switch manually
-            // In the future, we could read the first few lines to detect memreport format
-            return 'log';
-        }
-        
-        // Default to log for .log files and others
-        return 'log';
-    }
-
-    // Enhanced file type detection with content analysis
     async detectFileTypeWithContent(file) {
         const fileName = file.name.toLowerCase();
-        
-        // Check file extension first
-        if (fileName.endsWith('.memreport')) {
-            return 'memreport';
-        }
-        
-        // For .txt files, read first few lines to detect memreport format
+        if (fileName.endsWith('.memreport')) return 'memreport';
         if (fileName.endsWith('.txt')) {
             try {
-                const firstChunk = await this.readFileChunk(file, 0, 2048); // Read first 2KB
-                if (this.isMemReportContent(firstChunk)) {
-                    return 'memreport';
-                }
-            } catch (error) {
-                console.warn('Could not read file content for type detection:', error);
-            }
+                const firstChunk = await this.readFileChunk(file, 0, 2048);
+                if (this.isMemReportContent(firstChunk)) return 'memreport';
+            } catch (e) { console.warn('Could not read file chunk for type detection:', e); }
         }
-        
-        // Default to log for .log files and others
         return 'log';
     }
 
-    // Read a chunk of file content
     readFileChunk(file, start, length) {
         return new Promise((resolve, reject) => {
             const reader = new FileReader();
             reader.onload = (e) => resolve(e.target.result);
-            reader.onerror = (e) => reject(new Error('Failed to read file chunk'));
-            
-            const blob = file.slice(start, start + length);
-            reader.readAsText(blob);
+            reader.onerror = () => reject(new Error('Failed to read file chunk'));
+            reader.readAsText(file.slice(start, start + length));
         });
     }
 
-    // Check if content looks like a memreport file
     isMemReportContent(content) {
-        const memreportIndicators = [
+        return [
             /^=+\s*(Memory Overview|Platform Memory|Memory Summary)\s*=+$/im,
             /^=+\s*Obj List.*=+$/im,
             /^=+\s*(RHI|Rendering).*Memory.*=+$/im,
@@ -409,275 +195,271 @@ class LogAnalyzerApp {
             /^=+\s*Actors.*=+$/im,
             /^=+\s*(ListTextures|Texture).*=+$/im,
             /^=+\s*(ListStaticMeshes|Static.*Mesh).*=+$/im
-        ];
-        
-        // Check if content contains memreport section headers
-        return memreportIndicators.some(pattern => pattern.test(content));
+        ].some(p => p.test(content));
     }
 
-    // Handle log file upload — reads file in the browser, no server upload.
+    // ── Crash-first panel ────────────────────────────────────────────────────
+    // Categories whose Error-level entries are always surfaced in the crash panel.
+    static get CRASH_CATEGORIES() {
+        return new Set(['LogOutputDevice', 'LogWindows', 'LogCore', 'LogInit']);
+    }
+
+    isCrashEntry(entry) {
+        const c = entry.content;
+        if (/^Fatal\b|Fatal error:/i.test(c))     return true;
+        if (c.includes('Ensure condition failed')) return true;
+        if (c.includes('Assertion failed'))        return true;
+        if (LogAnalyzerApp.CRASH_CATEGORIES.has(entry.type) && /\bError\b/.test(c)) return true;
+        return false;
+    }
+
+    renderCrashPanel(allEntries) {
+        const panel = document.getElementById('crashPanel');
+        const badge = document.getElementById('crashPanelBadge');
+        const list  = document.getElementById('crashPanelList');
+        if (!panel || !badge || !list) return;
+
+        const crashes = allEntries.filter(e => this.isCrashEntry(e));
+
+        if (crashes.length === 0) { panel.style.display = 'none'; return; }
+
+        panel.style.display = '';
+        badge.textContent = crashes.length;
+
+        list.innerHTML = '';
+        const fragment = document.createDocumentFragment();
+
+        crashes.forEach(entry => {
+            const lines     = entry.content.split('\n');
+            const firstLine = lines[0] || '';
+            const callstack = lines.slice(1, 51).join('\n');
+
+            let label = 'Error', labelClass = 'crash-label-error';
+            if (/^Fatal\b|Fatal error:/i.test(entry.content))    { label = 'Fatal';  labelClass = 'crash-label-fatal'; }
+            else if (entry.content.includes('Ensure condition failed')) { label = 'Ensure'; labelClass = 'crash-label-ensure'; }
+            else if (entry.content.includes('Assertion failed'))        { label = 'Assert'; labelClass = 'crash-label-ensure'; }
+
+            const item = document.createElement('div');
+            item.className = 'crash-entry';
+            item.setAttribute('tabindex', '0');
+            item.setAttribute('role', 'button');
+            item.setAttribute('aria-label', `${label}: ${firstLine.slice(0, 100)}`);
+            item.title = 'Click to scroll to this entry in the main log';
+
+            const header = document.createElement('div');
+            header.className = 'crash-entry-header';
+
+            const labelSpan = document.createElement('span');
+            labelSpan.className = `crash-label ${labelClass}`;
+            labelSpan.textContent = label;
+
+            const typeSpan = document.createElement('span');
+            typeSpan.className = 'crash-type';
+            typeSpan.textContent = entry.type;
+
+            const preview = document.createElement('span');
+            preview.className = 'crash-content-preview';
+            preview.textContent = firstLine;
+            preview.title = firstLine;
+
+            header.appendChild(labelSpan);
+            header.appendChild(typeSpan);
+            header.appendChild(preview);
+            item.appendChild(header);
+
+            if (callstack) {
+                const pre = document.createElement('pre');
+                pre.className = 'crash-callstack';
+                pre.textContent = callstack;
+                item.appendChild(pre);
+            }
+
+            const scrollTo = () => this.scrollToCrashEntry(entry);
+            item.addEventListener('click', scrollTo);
+            item.addEventListener('keydown', e => {
+                if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); scrollTo(); }
+            });
+
+            fragment.appendChild(item);
+        });
+
+        list.appendChild(fragment);
+    }
+
+    // Scroll to and briefly highlight a crash entry in the main log view.
+    scrollToCrashEntry(entry) {
+        const logContent = document.getElementById('logContent');
+        if (!logContent) return;
+
+        const key = entry.type + ':' + entry.content.slice(0, 200);
+
+        const findEl = () => {
+            for (const el of logContent.querySelectorAll('.log-entry')) {
+                if (el.dataset.crashKey === key) return el;
+            }
+            return null;
+        };
+
+        let target = findEl();
+        if (!target) {
+            // Entry is filtered out — clear type + search filters and re-render.
+            this.appState.updateFilters({ types: [], search: '', useRegex: false });
+            this.updateDisplay();
+            target = findEl();
+        }
+
+        if (target) {
+            // Switch to the log tab if we're on another tab.
+            if (this.currentRoute !== 'log') this.switchRoute('log');
+            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            target.classList.add('crash-highlight');
+            target.focus();
+            setTimeout(() => target.classList.remove('crash-highlight'), 2500);
+        }
+    }
+    // ─────────────────────────────────────────────────────────────────────────
+
     async handleLogFileUpload() {
         const file = this.ui.elements.logFile.files[0];
-        
-        if (!file) {
-            Utils.showErrorToast('Please select a file');
-            return;
-        }
+        if (!file) { Utils.showErrorToast('Please select a file'); return; }
 
-        // Client-side size guard — reject files over 100 MB before reading.
         const MAX_LOG_SIZE = 100 * 1024 * 1024;
-        if (file.size > MAX_LOG_SIZE) {
-            Utils.showErrorToast('File too large — maximum is 100 MB.');
-            return;
-        }
+        if (file.size > MAX_LOG_SIZE) { Utils.showErrorToast('File too large \u2014 maximum is 100\u202fMB.'); return; }
 
-        // Show loading state
         this.ui.updateButtonText('Loading...');
         this.ui.setButtonDisabled(true);
-        
-        // Temporarily disable state subscriptions to prevent interference
         this.appState.pauseSubscriptions();
 
         try {
-            // Read the file entirely in the browser — no upload to server.
             const text = await new Promise((resolve, reject) => {
                 const reader = new FileReader();
-                reader.onload = (e) => resolve(e.target.result);
+                reader.onload  = (e) => resolve(e.target.result);
                 reader.onerror = () => reject(new Error('Failed to read file'));
                 reader.onabort = () => reject(new Error('File reading was aborted'));
                 reader.readAsText(file);
             });
 
-            // Validate: reject empty files.
-            if (text.trim().length === 0) {
-                throw new Error('File is empty.');
-            }
+            if (text.trim().length === 0) throw new Error('File is empty.');
 
-            // Validate: reject binary-looking content.
-            // Sample first 4 KB; allow tab (9), LF (10), VT (11), FF (12), CR (13).
-            // Null bytes and other low control chars strongly suggest binary data.
             const sampleSize = Math.min(text.length, 4096);
             let nonPrintable = 0;
             for (let i = 0; i < sampleSize; i++) {
                 const code = text.charCodeAt(i);
-                if (code === 0 || code < 9 || (code > 13 && code < 32)) {
-                    nonPrintable++;
-                }
+                if (code === 0 || code < 9 || (code > 13 && code < 32)) nonPrintable++;
             }
-            if (nonPrintable / sampleSize > 0.1) {
+            if (nonPrintable / sampleSize > 0.1)
                 throw new Error('File does not appear to be a text log file (binary content detected).');
-            }
 
             const data = LogParser.parseLogLines(text);
-
-            // First, update the data state
-            this.appState.update({
-                currentFile: file.name,
-                allEntries: data.entries,
-                logTypes: data.logTypes
-            });
-            
-            // Update UI
+            this.appState.update({ currentFile: file.name, allEntries: data.entries, logTypes: data.logTypes });
             this.ui.createLogTypeFilters(data.logTypes);
-            
-            // Update display directly
             this.updateDisplay();
-            
         } catch (error) {
             Utils.showErrorToast('Failed to read file: ' + error.message);
             console.error('File read error:', error);
         } finally {
-            // Reset UI state
             this.ui.updateButtonText('Refresh');
             this.ui.setButtonDisabled(false);
-            
-            // Re-enable state subscriptions
             this.appState.resumeSubscriptions();
         }
     }
 
-    // Handle memreport file upload
     async handleMemReportFileUpload() {
         const memreportFile = document.getElementById('memreportFile');
         const file = memreportFile?.files[0];
-        
-        if (!file) {
-            Utils.showErrorToast('Please select a memreport file');
-            return;
-        }
-
-        // Show loading state
+        if (!file) { Utils.showErrorToast('Please select a memreport file'); return; }
         const uploadButton = document.getElementById('memreportUploadButton');
-        if (uploadButton) {
-            uploadButton.textContent = 'Parsing...';
-            uploadButton.disabled = true;
-        }
-
+        if (uploadButton) { uploadButton.textContent = 'Parsing...'; uploadButton.disabled = true; }
         try {
-            // Initialize MemReport page if not already done
             if (!this.memreportPage) {
                 this.memreportPage = new MemReportPage(this.appState, this.ui, Utils);
                 this.memreportPage.initialize();
             }
-
-            // Use the MemReport page to parse and render the file
             await this.memreportPage.parseAndRender(file);
-            
-            // Update state with current file
-            this.appState.update({
-                currentFile: file.name
-            });
-            
+            this.appState.update({ currentFile: file.name });
         } catch (error) {
             Utils.showErrorToast('Failed to process memreport file: ' + error.message);
             console.error('MemReport processing error:', error);
-            
-            // Show error in the content area as well
-            const memreportContent = document.getElementById('memreportContent');
-            if (memreportContent) {
-                memreportContent.innerHTML = `
-                    <div class="alert alert-danger" role="alert">
-                        <h4 class="alert-heading">Processing Failed</h4>
-                        <p>Failed to process the memreport file: ${Utils.sanitizeInput(error.message)}</p>
-                        <hr>
-                        <p class="mb-0">Please try with a different file or check the browser console for more details.</p>
-                    </div>
-                `;
-            }
+            const mc = document.getElementById('memreportContent');
+            if (mc) mc.innerHTML = `<div class="alert alert-danger"><h4>Processing Failed</h4><p>${Utils.sanitizeInput(error.message)}</p></div>`;
         } finally {
-            // Reset UI state
-            if (uploadButton) {
-                uploadButton.textContent = 'Analyze MemReport';
-                uploadButton.disabled = false;
-            }
+            if (uploadButton) { uploadButton.textContent = 'Analyze MemReport'; uploadButton.disabled = false; }
         }
     }
 
-    // Handle file upload (legacy method for backward compatibility)
-    async handleFileUpload() {
-        return this.handleLogFileUpload();
-    }
+    async handleFileUpload() { return this.handleLogFileUpload(); }
 
-    // Handle paste log analysis — parses in the browser, no server round-trip.
     async handlePasteAnalyze() {
         const textarea = document.getElementById('pasteLogText');
         const text = textarea ? textarea.value : '';
-
-        if (!text.trim()) {
-            Utils.showErrorToast('Please paste some log content first');
-            return;
-        }
-
+        if (!text.trim()) { Utils.showErrorToast('Please paste some log content first'); return; }
         const analyzeButton = document.getElementById('pasteAnalyzeButton');
-        if (analyzeButton) {
-            analyzeButton.textContent = 'Analyzing...';
-            analyzeButton.disabled = true;
-        }
-
+        if (analyzeButton) { analyzeButton.textContent = 'Analyzing...'; analyzeButton.disabled = true; }
         this.appState.pauseSubscriptions();
-
         try {
-            // Parse entirely in the browser — no server round-trip.
             const data = LogParser.parseLogLines(text);
-
-            this.appState.update({
-                currentFile: 'pasted-log',
-                allEntries: data.entries,
-                logTypes: data.logTypes
-            });
-
+            this.appState.update({ currentFile: 'pasted-log', allEntries: data.entries, logTypes: data.logTypes });
             this.ui.createLogTypeFilters(data.logTypes);
             this.updateDisplay();
         } catch (error) {
             Utils.showErrorToast('Failed to parse log: ' + error.message);
             console.error('Parse error:', error);
         } finally {
-            if (analyzeButton) {
-                analyzeButton.textContent = 'Analyze';
-                analyzeButton.disabled = false;
-            }
+            if (analyzeButton) { analyzeButton.textContent = 'Analyze'; analyzeButton.disabled = false; }
             this.appState.resumeSubscriptions();
         }
     }
 
-    // Handle search change
     handleSearchChange() {
         const searchTerm = this.ui.getSearchTerm();
         const searchOptions = this.ui.getSearchOptions();
-
-        // Regex DoS guard — reject patterns longer than 200 chars.
         if (searchOptions.useRegex && searchTerm.length > 200) {
-            Utils.showErrorToast('Regex pattern too long — maximum is 200 characters.');
+            Utils.showErrorToast('Regex pattern too long \u2014 maximum is 200 characters.');
             return;
         }
-
-        this.appState.updateFilters({ 
-            search: searchTerm,
-            caseSensitive: searchOptions.caseSensitive,
-            useRegex: searchOptions.useRegex
-        });
+        this.appState.updateFilters({ search: searchTerm, caseSensitive: searchOptions.caseSensitive, useRegex: searchOptions.useRegex });
         this.updateDisplay();
     }
 
-    // Handle level filter change
     handleLevelFilterChange() {
-        const selectedLevels = this.ui.getSelectedLogLevels();
-        this.appState.updateFilters({ levels: selectedLevels });
+        this.appState.updateFilters({ levels: this.ui.getSelectedLogLevels() });
         this.updateDisplay();
     }
 
-    // Handle search options change
     handleSearchOptionsChange() {
         const searchOptions = this.ui.getSearchOptions();
-        this.appState.updateFilters({ 
-            caseSensitive: searchOptions.caseSensitive,
-            useRegex: searchOptions.useRegex
-        });
+        this.appState.updateFilters({ caseSensitive: searchOptions.caseSensitive, useRegex: searchOptions.useRegex });
         this.updateDisplay();
     }
 
-    // Update display based on current state
     updateDisplay() {
         const state = this.appState.getState();
 
-        // Time regex searches and warn if slow (>300 ms) — part of DoS mitigation.
-        // Synchronous regex on large logs can block the main thread; surfacing the
-        // timing nudges users toward more specific patterns. Web Worker search
-        // (Task 2.4) will eliminate this entirely once implemented.
+        // Crash panel — derives from allEntries, not filtered view.
+        this.renderCrashPanel(state.allEntries);
+
+        // Time regex searches and warn if slow (>300 ms).
         let filteredEntries;
         if (state.filters.useRegex && state.filters.search) {
             const t0 = performance.now();
             filteredEntries = this.appState.getFilteredEntries();
             const elapsed = performance.now() - t0;
-            if (elapsed > 300) {
-                Utils.showInfoToast(
-                    `Regex search took ${Math.round(elapsed)} ms — try a more specific pattern.`,
-                    'Slow search'
-                );
-            }
+            if (elapsed > 300)
+                Utils.showInfoToast(`Regex search took ${Math.round(elapsed)}\u202fms \u2014 try a more specific pattern.`, 'Slow search');
         } else {
             filteredEntries = this.appState.getFilteredEntries();
         }
 
-        // Update UI
         this.ui.displayLogEntries(filteredEntries);
         this.ui.updateLogLevelCounts(filteredEntries);
         this.ui.updateLogTypeCounts(filteredEntries, state.logTypes);
     }
 
-    // Initialize the application
-    static init() {
-        return new LogAnalyzerApp();
-    }
+    static init() { return new LogAnalyzerApp(); }
 }
 
-// Initialize app when DOM is ready
 if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => {
-        window.app = LogAnalyzerApp.init();
-    });
+    document.addEventListener('DOMContentLoaded', () => { window.app = LogAnalyzerApp.init(); });
 } else {
-    setTimeout(() => {
-        window.app = LogAnalyzerApp.init();
-    }, 100);
+    setTimeout(() => { window.app = LogAnalyzerApp.init(); }, 100);
 }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,8 +1,7 @@
-// UI management and rendering - VERSION 1.5
+// UI management and rendering - VERSION 1.6
 
 class UI {
     constructor() {
-        // Don't initialize elements immediately - wait for app to call initialize()
         this.elements = {};
         this.initialized = false;
     }
@@ -30,145 +29,87 @@ class UI {
         };
     }
 
-    // Initialize UI after app is ready
     initialize() {
-        if (this.initialized) {
-            return;
-        }
-        
-        // Wait for DOM to be ready
+        if (this.initialized) return;
         if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', () => {
-                this.initialize();
-            });
+            document.addEventListener('DOMContentLoaded', () => this.initialize());
             return;
         }
-        
-        // Check for dependencies
         console.log('Checking dependencies...');
         console.log('Bootstrap available:', typeof bootstrap !== 'undefined');
         console.log('jQuery available:', typeof $ !== 'undefined');
-        
-        // Initialize elements first
         this.initializeElements();
-        
-        // Drag and drop is now handled by app.js setupDragAndDrop()
-        // this.setupDragAndDrop();
         console.log('Setting up search history...');
         this.setupSearchHistory();
         console.log('Setting up keyboard navigation...');
         this.setupKeyboardNavigation();
-
         if (this.elements.multiSelect) {
-            this.elements.multiSelect.addEventListener('change', () => {
-                window.app.updateDisplay();
-            });
+            this.elements.multiSelect.addEventListener('change', () => window.app.updateDisplay());
         }
-
         this.initialized = true;
     }
 
-    // Setup drag and drop functionality - REMOVED
-    // This functionality is now handled by app.js setupDragAndDrop() 
-    // to avoid duplicate event listeners that cause the file dialog to open twice
-    setupDragAndDrop() {
-        // Drag and drop functionality moved to app.js to handle both log and memreport files
-        // and prevent duplicate event listeners
-        return;
-    }
+    setupDragAndDrop() { return; }
 
-    // Setup search history functionality
     setupSearchHistory() {
         const historyContainer = this.elements.searchHistory;
         const clearHistoryBtn = this.elements.clearHistory;
-        
-        // Check if elements exist
-        if (!historyContainer || !clearHistoryBtn) {
-            return;
-        }
-        
-        // Update search history display
+        if (!historyContainer || !clearHistoryBtn) return;
         const updateHistoryDisplay = () => {
             if (!window.app || !window.app.appState) return;
-            
             const history = window.app.appState.getState().searchHistory;
-            
             if (history.length === 0) {
                 historyContainer.innerHTML = '<em class="text-muted">No recent searches</em>';
                 return;
             }
-            
-            historyContainer.innerHTML = history.map(term => 
+            historyContainer.innerHTML = history.map(term =>
                 `<button class="dropdown-item search-history-item" data-term="${Utils.sanitizeInput(term)}">${Utils.sanitizeInput(term)}</button>`
             ).join('');
-            
-            // Add click handlers to history items
             historyContainer.querySelectorAll('.search-history-item').forEach(button => {
                 button.addEventListener('click', () => {
-                    const term = button.dataset.term;
-                    this.elements.logSearchInput.value = term;
+                    this.elements.logSearchInput.value = button.dataset.term;
                     this.elements.logSearchInput.dispatchEvent(new Event('input'));
                 });
             });
         };
-
-        // Clear history button
         clearHistoryBtn.addEventListener('click', () => {
             if (window.app && window.app.appState) {
                 window.app.appState.clearSearchHistory();
                 updateHistoryDisplay();
             }
         });
-
-        // Subscribe to state changes for history updates
         if (window.app && window.app.appState) {
-            window.app.appState.subscribe(() => {
-                updateHistoryDisplay();
-            });
+            window.app.appState.subscribe(() => updateHistoryDisplay());
         }
     }
 
-    // Display log entries with DocumentFragment for performance
     displayLogEntries(entries) {
-        // Remove only log entries, preserve the copy button and export buttons
         const logEntries = this.elements.logContent.querySelectorAll('.log-entry');
         logEntries.forEach(entry => entry.remove());
-        
-        // Use DocumentFragment for batch DOM updates
         const fragment = document.createDocumentFragment();
-        
         entries.forEach(entry => {
             const div = Utils.createElement('div', 'log-entry', { tabindex: '0' });
+            // Store crash-key so crash panel click-to-scroll can find this element.
+            div.dataset.crashKey = entry.type + ':' + entry.content.slice(0, 200);
+
             const level = window.app.appState.detectLogLevel(entry.content);
             const levelClass = Utils.getLogLevelClass(level);
-
-            // Show timestamp prefix if present (timestamped log format)
-            // When duplicates are collapsed, show the last occurrence's timestamp
             const displayTimestamp = (entry.duplicateCount > 1 && entry.lastTimestamp)
-                ? entry.lastTimestamp
-                : entry.timestamp;
+                ? entry.lastTimestamp : entry.timestamp;
             if (displayTimestamp) {
                 const timestampSpan = Utils.createElement('span', 'log-timestamp');
                 timestampSpan.textContent = `[${displayTimestamp}]`;
                 div.appendChild(timestampSpan);
                 div.appendChild(Utils.createTextNode(' '));
             }
-
-            // Create spans for proper styling without XSS vulnerability
             const typeSpan = Utils.createElement('span', 'log-type');
             typeSpan.textContent = entry.type;
-
             const contentSpan = Utils.createElement('span', levelClass);
             contentSpan.textContent = entry.content;
-            // pre-wrap so multi-line continuation content (e.g. callstacks) renders
-            // with preserved line breaks rather than collapsing to one long line.
             contentSpan.style.whiteSpace = 'pre-wrap';
-
             div.appendChild(typeSpan);
             div.appendChild(Utils.createTextNode(' '));
             div.appendChild(contentSpan);
-
-            // Show duplicate count badge when entries are collapsed
             if (entry.duplicateCount > 1) {
                 div.appendChild(Utils.createTextNode(' '));
                 const badge = Utils.createElement('span', 'badge log-duplicate-badge');
@@ -176,27 +117,19 @@ class UI {
                 badge.textContent = `\u00d7${entry.duplicateCount}`;
                 div.appendChild(badge);
             }
-
             fragment.appendChild(div);
         });
-        
         this.elements.logContent.appendChild(fragment);
-        
-        // Announce to screen readers
         Utils.announceToScreenReader(`Displaying ${Utils.formatNumber(entries.length)} log entries`);
     }
 
-    // Create log type filters
     createLogTypeFilters(logTypes) {
         this.elements.logTypeFilters.innerHTML = '';
-        
         const fragment = document.createDocumentFragment();
-        
         logTypes.forEach(typeObj => {
             const type = typeObj.type;
             const count = typeObj.count;
             const col = Utils.createElement('div', 'col-md-3 mb-2');
-            
             const checkbox = Utils.createElement('div', 'form-check');
             checkbox.innerHTML = `
                 <input class="form-check-input" type="checkbox" value="${Utils.sanitizeInput(type)}" id="filter_${Utils.sanitizeInput(type)}">
@@ -204,43 +137,30 @@ class UI {
                     ${Utils.sanitizeInput(type)} <span class="badge bg-secondary" id="badge-type-${Utils.sanitizeInput(type)}">${count}</span>
                 </label>
             `;
-            
-            checkbox.querySelector('input').addEventListener('change', () => {
-                this.updateTypeFilters();
-            });
-            
+            checkbox.querySelector('input').addEventListener('change', () => this.updateTypeFilters());
             col.appendChild(checkbox);
             fragment.appendChild(col);
         });
-        
         this.elements.logTypeFilters.appendChild(fragment);
     }
 
-    // Update log level counts
     updateLogLevelCounts(entries) {
         const counts = { Display: 0, Warning: 0, Error: 0 };
         entries.forEach(entry => {
             const level = window.app.appState.detectLogLevel(entry.content);
-            if (level && counts.hasOwnProperty(level)) {
-                counts[level]++;
-            }
+            if (level && counts.hasOwnProperty(level)) counts[level]++;
         });
-        
         document.getElementById('count-Display').textContent = counts.Display;
         document.getElementById('count-Warning').textContent = counts.Warning;
         document.getElementById('count-Error').textContent = counts.Error;
     }
 
-    // Update log type counts
     updateLogTypeCounts(entries, logTypes) {
         const multiSelect = this.elements.multiSelect && this.elements.multiSelect.checked;
         const state = window.app.appState.getState();
         const counts = {};
         logTypes.forEach(typeObj => counts[typeObj.type] = 0);
-
         if (multiSelect) {
-            // In multi-select mode, count each category using level+search filters only
-            // (ignoring the type filter) so selecting one category doesn't zero out the others.
             state.allEntries.forEach(entry => {
                 if (!counts.hasOwnProperty(entry.type)) return;
                 const level = window.app.appState.detectLogLevel(entry.content);
@@ -261,14 +181,10 @@ class UI {
                 counts[entry.type]++;
             });
         } else {
-            // Normal mode: entries are already filtered by type+level+search
             entries.forEach(entry => {
                 if (counts.hasOwnProperty(entry.type)) counts[entry.type]++;
             });
         }
-
-        // Compute level-only counts to decide category visibility in multi-select mode.
-        // A category is only eligible to appear if it has entries that pass the level filter.
         let levelCounts = null;
         if (multiSelect) {
             levelCounts = {};
@@ -279,7 +195,6 @@ class UI {
                 if (levelCounts.hasOwnProperty(entry.type)) levelCounts[entry.type]++;
             });
         }
-
         logTypes.forEach(typeObj => {
             const badge = document.getElementById(`badge-type-${typeObj.type}`);
             if (badge) {
@@ -294,7 +209,6 @@ class UI {
         });
     }
 
-    // Update type filters from UI
     updateTypeFilters() {
         const selectedTypes = Array.from(document.querySelectorAll('#logTypeFilters input:checked'))
             .map(checkbox => checkbox.value);
@@ -302,63 +216,35 @@ class UI {
         window.app.updateDisplay();
     }
 
-    // Get selected log levels from UI
     getSelectedLogLevels() {
-        return Array.from(document.querySelectorAll('.log-level-filter:checked'))
-            .map(cb => cb.value);
+        return Array.from(document.querySelectorAll('.log-level-filter:checked')).map(cb => cb.value);
     }
 
-    // Get search term from UI
-    getSearchTerm() {
-        return this.elements.logSearchInput.value.trim();
-    }
+    getSearchTerm() { return this.elements.logSearchInput.value.trim(); }
 
-    // Get collapse duplicates setting from UI
     getCollapseDuplicates() {
         return this.elements.collapseDuplicates ? this.elements.collapseDuplicates.checked : false;
     }
 
-    // Get search options from UI
     getSearchOptions() {
         const options = {
             caseSensitive: this.elements.caseSensitive.checked,
             useRegex: this.elements.useRegex.checked
         };
-        
-        // Validate regex if enabled
         if (options.useRegex && this.elements.logSearchInput.value) {
             if (!Utils.isValidRegex(this.elements.logSearchInput.value)) {
                 Utils.showErrorToast('Invalid regular expression pattern');
-                return {
-                    caseSensitive: options.caseSensitive,
-                    useRegex: false // Disable regex on invalid pattern
-                };
+                return { caseSensitive: options.caseSensitive, useRegex: false };
             }
         }
-        
         return options;
     }
 
-    // Update button text
-    updateButtonText(text) {
-        this.elements.uploadButton.textContent = text;
-    }
+    updateButtonText(text) { this.elements.uploadButton.textContent = text; }
+    setButtonDisabled(disabled) { this.elements.uploadButton.disabled = disabled; }
+    focusSearchInput() { this.elements.logSearchInput.focus(); }
+    focusCopyButton() { this.elements.copyButton.focus(); }
 
-    // Set button disabled state
-    setButtonDisabled(disabled) {
-        this.elements.uploadButton.disabled = disabled;
-    }
-
-    // Focus management for accessibility
-    focusSearchInput() {
-        this.elements.logSearchInput.focus();
-    }
-
-    focusCopyButton() {
-        this.elements.copyButton.focus();
-    }
-
-    // Export functionality
     exportToCsv() {
         const entries = window.app.appState.getFilteredEntries();
         const headers = ['Type', 'Level', 'Content'];
@@ -367,72 +253,39 @@ class UI {
             window.app.appState.detectLogLevel(entry.content),
             entry.content
         ]);
-        const csvContent = Utils.tableToCSV(headers, rows);
-        this.downloadFile(csvContent, 'log_entries.csv', 'text/csv');
+        this.downloadFile(Utils.tableToCSV(headers, rows), 'log_entries.csv', 'text/csv');
     }
 
     exportToJson() {
         const entries = window.app.appState.getFilteredEntries();
-        const jsonContent = JSON.stringify(entries, null, 2);
-        this.downloadFile(jsonContent, 'log_entries.json', 'application/json');
+        this.downloadFile(JSON.stringify(entries, null, 2), 'log_entries.json', 'application/json');
     }
 
-    // generateCsvContent method removed - now using Utils.tableToCSV() to avoid duplication
+    downloadFile(content, filename, mimeType) { Utils.downloadAsFile(content, filename, mimeType); }
 
-    downloadFile(content, filename, mimeType) {
-        // Use the centralized utility function to avoid duplication
-        Utils.downloadAsFile(content, filename, mimeType);
-    }
-
-    // Keyboard navigation support
     setupKeyboardNavigation() {
-        // Focus trap for modal-like behavior
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
-                // Close any open dropdowns or modals
-                const openDropdowns = document.querySelectorAll('.collapse.show');
-                openDropdowns.forEach(dropdown => {
+                document.querySelectorAll('.collapse.show').forEach(dropdown => {
                     const bsCollapse = bootstrap.Collapse.getInstance(dropdown);
                     if (bsCollapse) bsCollapse.hide();
                 });
             }
-            
-            // Global keyboard shortcuts
             if (e.ctrlKey || e.metaKey) {
                 switch (e.key) {
-                    case 'f':
-                        e.preventDefault();
-                        this.focusSearchInput();
-                        break;
-                    case 'c':
-                        e.preventDefault();
-                        this.copyFilteredResults();
-                        break;
-                    case 'o':
-                        e.preventDefault();
-                        this.elements.logFile.click();
-                        break;
-                    case 's':
-                        e.preventDefault();
-                        this.exportToCsv();
-                        break;
-                    case 'j':
-                        e.preventDefault();
-                        this.exportToJson();
-                        break;
+                    case 'f': e.preventDefault(); this.focusSearchInput(); break;
+                    case 'c': e.preventDefault(); this.copyFilteredResults(); break;
+                    case 'o': e.preventDefault(); this.elements.logFile.click(); break;
+                    case 's': e.preventDefault(); this.exportToCsv(); break;
+                    case 'j': e.preventDefault(); this.exportToJson(); break;
                 }
             }
         });
-
-        // Search input keyboard shortcuts
         this.elements.logSearchInput.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') {
                 e.preventDefault();
-                // Add to search history and trigger search
                 const term = this.getSearchTerm();
-                if (term) {
-                    window.app.appState.addToSearchHistory(term);
-                }
+                if (term) window.app.appState.addToSearchHistory(term);
                 this.elements.copyButton.focus();
             } else if (e.key === 'Escape') {
                 e.preventDefault();
@@ -440,93 +293,53 @@ class UI {
                 this.elements.logSearchInput.dispatchEvent(new Event('input'));
             }
         });
-
-        // Copy button keyboard shortcuts
         this.elements.copyButton.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                this.copyFilteredResults();
-            }
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.copyFilteredResults(); }
         });
-
-        // Export buttons keyboard shortcuts
         this.elements.exportCsv.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                this.exportToCsv();
-            }
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.exportToCsv(); }
         });
-
         this.elements.exportJson.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                this.exportToJson();
-            }
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this.exportToJson(); }
         });
-
-        // Log container keyboard navigation
         this.elements.logContent.addEventListener('keydown', (e) => {
             const logEntries = this.elements.logContent.querySelectorAll('.log-entry');
-            const currentIndex = Array.from(logEntries).findIndex(entry => 
+            const currentIndex = Array.from(logEntries).findIndex(entry =>
                 entry === document.activeElement || entry.contains(document.activeElement)
             );
-
             switch (e.key) {
                 case 'ArrowDown':
                     e.preventDefault();
-                    if (currentIndex < logEntries.length - 1) {
-                        logEntries[currentIndex + 1].focus();
-                    }
+                    if (currentIndex < logEntries.length - 1) logEntries[currentIndex + 1].focus();
                     break;
                 case 'ArrowUp':
                     e.preventDefault();
-                    if (currentIndex > 0) {
-                        logEntries[currentIndex - 1].focus();
-                    } else {
-                        this.elements.copyButton.focus();
-                    }
+                    if (currentIndex > 0) logEntries[currentIndex - 1].focus();
+                    else this.elements.copyButton.focus();
                     break;
                 case 'Home':
                     e.preventDefault();
-                    if (logEntries.length > 0) {
-                        logEntries[0].focus();
-                    }
+                    if (logEntries.length > 0) logEntries[0].focus();
                     break;
                 case 'End':
                     e.preventDefault();
-                    if (logEntries.length > 0) {
-                        logEntries[logEntries.length - 1].focus();
-                    }
+                    if (logEntries.length > 0) logEntries[logEntries.length - 1].focus();
                     break;
             }
         });
-
-        // Make log entries focusable
         this.elements.logContent.addEventListener('click', (e) => {
-            if (e.target.classList.contains('log-entry')) {
-                e.target.focus();
-            }
+            if (e.target.classList.contains('log-entry')) e.target.focus();
         });
     }
 
-    // Copy filtered results to clipboard
     async copyFilteredResults() {
         const entries = window.app.appState.getFilteredEntries();
-        if (entries.length === 0) {
-            Utils.showErrorToast('No entries to copy');
-            return;
-        }
-
+        if (entries.length === 0) { Utils.showErrorToast('No entries to copy'); return; }
         const text = entries.map(entry => `${entry.type}: ${entry.content}`).join('\n');
         const success = await Utils.copyToClipboard(text);
-        
-        if (success) {
-            Utils.showSuccessToast('Copied to clipboard!');
-        } else {
-            Utils.showErrorToast('Failed to copy to clipboard');
-        }
+        if (success) Utils.showSuccessToast('Copied to clipboard!');
+        else Utils.showErrorToast('Failed to copy to clipboard');
     }
 }
 
-// Export for use in other modules
 window.UI = UI;

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,359 +11,179 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="/static/css/memreport.css?v=1.3" rel="stylesheet">
     <style>
-        body {
-            background-color: #181a1b;
-            color: #e0e0e0;
-            padding: 20px;
-        }
-        .container {
-            background: none;
-        }
+        body { background-color: #181a1b; color: #e0e0e0; padding: 20px; }
+        .container { background: none; }
         .log-container {
-            background-color: #23272b;
-            color: #e0e0e0;
+            background-color: #23272b; color: #e0e0e0;
             font-family: 'Consolas', monospace;
-            padding: 15px;
-            border-radius: 5px;
-            height: 70vh;
-            overflow-y: auto;
-            margin-top: 20px;
-            border: 1px solid #333;
-            position: relative;
+            padding: 15px; border-radius: 5px;
+            height: 70vh; overflow-y: auto;
+            margin-top: 20px; border: 1px solid #333; position: relative;
         }
-        .log-entry {
-            margin: 2px 0;
-            padding: 2px 5px;
-            border-radius: 3px;
-        }
-        .log-entry:hover {
-            background-color: #2d3136;
-        }
+        .log-entry { margin: 2px 0; padding: 2px 5px; border-radius: 3px; }
+        .log-entry:hover { background-color: #2d3136; }
         .filters-container, .upload-container {
-            background-color: #23272b;
-            padding: 15px;
-            border-radius: 5px;
-            box-shadow: none;
-            border: 1px solid #333;
+            background-color: #23272b; padding: 15px; border-radius: 5px;
+            box-shadow: none; border: 1px solid #333;
         }
-        .filters-container {
-            margin-bottom: 20px;
-        }
-        .form-label, h1, h5, label, .form-check-label {
-            color: #e0e0e0;
-        }
-        .form-control {
-            background-color: #23272b;
-            color: #e0e0e0;
-            border: 1px solid #444;
-        }
-        .form-control:focus {
-            background-color: #23272b;
-            color: #fff;
-            border-color: #888;
-        }
-        .form-check-input {
-            background-color: #23272b;
-            border: 1px solid #444;
-        }
-        .form-check-input:checked {
-            background-color: #007bff;
-            border-color: #007bff;
-        }
-        .btn-primary {
-            background-color: #007bff;
-            border: none;
-        }
-        .btn-primary:hover, .btn-primary:focus {
-            background-color: #0056b3;
-        }
-        .badge.bg-secondary {
-            background-color: #444 !important;
-            color: #e0e0e0;
-        }
-        a.text-decoration-none, a.text-decoration-none:visited {
-            color: #e0e0e0;
-        }
-        a.text-decoration-none:hover {
-            color: #007bff;
-        }
-        /* Scrollbar styling */
-        ::-webkit-scrollbar {
-            width: 10px;
-            background: #23272b;
-        }
-        ::-webkit-scrollbar-thumb {
-            background: #333;
-            border-radius: 5px;
-        }
-        ::-webkit-scrollbar-thumb:hover {
-            background: #444;
-        }
-        .log-timestamp {
-            color: #78909c;
-            font-size: 0.85em;
-        }
-        .log-type {
-            color: #4fc3f7;
-            font-weight: bold;
-        }
-        .log-level-display {
-            color: #a5d6a7;
-        }
-        .log-level-warning {
-            color: #ffd54f;
-        }
-        .log-level-error {
-            color: #ef9a9a;
-        }
+        .filters-container { margin-bottom: 20px; }
+        .form-label, h1, h5, label, .form-check-label { color: #e0e0e0; }
+        .form-control { background-color: #23272b; color: #e0e0e0; border: 1px solid #444; }
+        .form-control:focus { background-color: #23272b; color: #fff; border-color: #888; }
+        .form-check-input { background-color: #23272b; border: 1px solid #444; }
+        .form-check-input:checked { background-color: #007bff; border-color: #007bff; }
+        .btn-primary { background-color: #007bff; border: none; }
+        .btn-primary:hover, .btn-primary:focus { background-color: #0056b3; }
+        .badge.bg-secondary { background-color: #444 !important; color: #e0e0e0; }
+        a.text-decoration-none, a.text-decoration-none:visited { color: #e0e0e0; }
+        a.text-decoration-none:hover { color: #007bff; }
+        ::-webkit-scrollbar { width: 10px; background: #23272b; }
+        ::-webkit-scrollbar-thumb { background: #333; border-radius: 5px; }
+        ::-webkit-scrollbar-thumb:hover { background: #444; }
+        .log-timestamp { color: #78909c; font-size: 0.85em; }
+        .log-type { color: #4fc3f7; font-weight: bold; }
+        .log-level-display { color: #a5d6a7; }
+        .log-level-warning { color: #ffd54f; }
+        .log-level-error { color: #ef9a9a; }
         .copy-button {
-            background-color: #007bff;
-            border: none;
-            color: white;
-            padding: 8px 12px;
-            border-radius: 4px;
-            cursor: pointer;
-            z-index: 10;
-            transition: background-color 0.2s;
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            font-size: 0.9rem;
+            background-color: #007bff; border: none; color: white;
+            padding: 8px 12px; border-radius: 4px; cursor: pointer;
+            z-index: 10; transition: background-color 0.2s;
+            display: flex; align-items: center; gap: 6px; font-size: 0.9rem;
         }
-        .copy-button:hover {
-            background-color: #0056b3;
-        }
-        .copy-button:active {
-            background-color: #004085;
-        }
-        .toast {
-            background-color: #23272b;
-            color: #e0e0e0;
-            border: 1px solid #333;
-        }
-        .toast-header {
-            background-color: #2d3136;
-            color: #e0e0e0;
-            border-bottom: 1px solid #333;
-        }
-        .btn-close {
-            filter: invert(1);
-        }
-        
-        /* Drag and Drop Zone */
+        .copy-button:hover { background-color: #0056b3; }
+        .copy-button:active { background-color: #004085; }
+        .toast { background-color: #23272b; color: #e0e0e0; border: 1px solid #333; }
+        .toast-header { background-color: #2d3136; color: #e0e0e0; border-bottom: 1px solid #333; }
+        .btn-close { filter: invert(1); }
         .drop-zone {
-            border: 2px dashed #444;
-            border-radius: 8px;
-            padding: 40px 20px;
-            text-align: center;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            background-color: #1e2124;
-            position: relative;
+            border: 2px dashed #444; border-radius: 8px;
+            padding: 40px 20px; text-align: center; cursor: pointer;
+            transition: all 0.3s ease; background-color: #1e2124; position: relative;
         }
-        
-        .drop-zone:hover {
-            border-color: #007bff;
-            background-color: #2a2d30;
-        }
-        
-        .drop-zone.drag-over {
-            border-color: #28a745;
-            background-color: #1e3a1e;
-            transform: scale(1.02);
-        }
-        
-        .drop-zone.drag-over .drop-zone-text {
-            color: #28a745;
-        }
-        
-        .drop-zone-content {
-            pointer-events: none;
-        }
-        
-        .drop-zone-text {
-            font-size: 1.2rem;
-            font-weight: 500;
-            margin-bottom: 8px;
-            color: #e0e0e0;
-        }
-        
-        .drop-zone-subtext {
-            font-size: 0.9rem;
-            color: #888;
-            margin: 0;
-        }
-        
+        .drop-zone:hover { border-color: #007bff; background-color: #2a2d30; }
+        .drop-zone.drag-over { border-color: #28a745; background-color: #1e3a1e; transform: scale(1.02); }
+        .drop-zone.drag-over .drop-zone-text { color: #28a745; }
+        .drop-zone-content { pointer-events: none; }
+        .drop-zone-text { font-size: 1.2rem; font-weight: 500; margin-bottom: 8px; color: #e0e0e0; }
+        .drop-zone-subtext { font-size: 0.9rem; color: #888; margin: 0; }
         .visually-hidden {
-            position: absolute !important;
-            width: 1px !important;
-            height: 1px !important;
-            padding: 0 !important;
-            margin: -1px !important;
-            overflow: hidden !important;
-            clip: rect(0, 0, 0, 0) !important;
-            white-space: nowrap !important;
-            border: 0 !important;
+            position: absolute !important; width: 1px !important; height: 1px !important;
+            padding: 0 !important; margin: -1px !important; overflow: hidden !important;
+            clip: rect(0,0,0,0) !important; white-space: nowrap !important; border: 0 !important;
         }
-        
-        /* Skip links for accessibility */
         .skip-link {
-            position: absolute;
-            top: -40px;
-            left: 6px;
-            background: #007bff;
-            color: white;
-            padding: 8px;
-            text-decoration: none;
-            border-radius: 4px;
-            z-index: 1000;
-            transition: top 0.3s;
+            position: absolute; top: -40px; left: 6px; background: #007bff;
+            color: white; padding: 8px; text-decoration: none; border-radius: 4px;
+            z-index: 1000; transition: top 0.3s;
         }
-        
-        .skip-link:focus {
-            top: 6px;
-        }
-        
-        /* Screen reader only class */
+        .skip-link:focus { top: 6px; }
         .sr-only {
-            position: absolute !important;
-            width: 1px !important;
-            height: 1px !important;
-            padding: 0 !important;
-            margin: -1px !important;
-            overflow: hidden !important;
-            clip: rect(0, 0, 0, 0) !important;
-            white-space: nowrap !important;
-            border: 0 !important;
+            position: absolute !important; width: 1px !important; height: 1px !important;
+            padding: 0 !important; margin: -1px !important; overflow: hidden !important;
+            clip: rect(0,0,0,0) !important; white-space: nowrap !important; border: 0 !important;
         }
-        
-        .export-buttons {
-            display: flex;
-            gap: 8px;
-            z-index: 10;
-            justify-content: flex-end;
-            margin-bottom: 10px;
-        }
-        
+        .export-buttons { display: flex; gap: 8px; z-index: 10; justify-content: flex-end; margin-bottom: 10px; }
         .export-button {
-            background-color: #28a745;
-            border: none;
-            color: white;
-            padding: 8px 12px;
-            border-radius: 4px;
-            cursor: pointer;
-            transition: background-color 0.2s;
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            font-size: 0.9rem;
+            background-color: #28a745; border: none; color: white;
+            padding: 8px 12px; border-radius: 4px; cursor: pointer;
+            transition: background-color 0.2s; display: flex; align-items: center; gap: 6px; font-size: 0.9rem;
         }
-        
-        .export-button:hover {
-            background-color: #218838;
-        }
-        
-        .export-button:active {
-            background-color: #1e7e34;
-        }
-        
-        #exportJson {
-            background-color: #6f42c1;
-        }
-        
-        #exportJson:hover {
-            background-color: #5a32a3;
-        }
-        
-        #exportJson:active {
-            background-color: #4c2b8a;
-        }
-
-        /* Input mode pills */
+        .export-button:hover { background-color: #218838; }
+        .export-button:active { background-color: #1e7e34; }
+        #exportJson { background-color: #6f42c1; }
+        #exportJson:hover { background-color: #5a32a3; }
+        #exportJson:active { background-color: #4c2b8a; }
         #inputModeTabs .nav-link {
-            color: #aaa;
-            background-color: transparent;
-            border: 1px solid #444;
-            margin-right: 4px;
-            transition: all 0.2s ease;
+            color: #aaa; background-color: transparent; border: 1px solid #444;
+            margin-right: 4px; transition: all 0.2s ease;
         }
-        #inputModeTabs .nav-link:hover {
-            color: #e0e0e0;
-            border-color: #666;
-            background-color: #2d3136;
-        }
-        #inputModeTabs .nav-link.active {
-            color: #fff;
-            background-color: #007bff;
-            border-color: #007bff;
-        }
-
-        /* Paste textarea */
-        #pasteLogText {
-            background-color: #1e2124;
-            color: #e0e0e0;
-            border: 1px solid #444;
-        }
-        #pasteLogText:focus {
-            background-color: #1e2124;
-            color: #fff;
-            border-color: #007bff;
-            box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.15);
-        }
-        #pasteLogText::placeholder {
-            color: #666;
-        }
+        #inputModeTabs .nav-link:hover { color: #e0e0e0; border-color: #666; background-color: #2d3136; }
+        #inputModeTabs .nav-link.active { color: #fff; background-color: #007bff; border-color: #007bff; }
+        #pasteLogText { background-color: #1e2124; color: #e0e0e0; border: 1px solid #444; }
+        #pasteLogText:focus { background-color: #1e2124; color: #fff; border-color: #007bff; box-shadow: 0 0 0 0.2rem rgba(0,123,255,0.15); }
+        #pasteLogText::placeholder { color: #666; }
         .log-duplicate-badge {
-            background-color: #5a6acf;
-            color: #fff;
-            font-size: 0.75em;
-            padding: 1px 5px;
-            border-radius: 3px;
-            vertical-align: middle;
-            font-weight: 600;
-            letter-spacing: 0.02em;
+            background-color: #5a6acf; color: #fff; font-size: 0.75em;
+            padding: 1px 5px; border-radius: 3px; vertical-align: middle;
+            font-weight: 600; letter-spacing: 0.02em;
+        }
+        /* ── Crash Panel ─────────────────────────────────────────────────────── */
+        .crash-panel-container {
+            background-color: #2a1a1a; border: 1px solid #6b2020;
+            border-radius: 5px; padding: 12px 15px; margin-top: 16px;
+        }
+        .crash-panel-toggle {
+            background: none; border: none; color: #ef9a9a;
+            font-size: 0.95rem; font-weight: 600; cursor: pointer;
+            padding: 0; display: flex; align-items: center; gap: 8px; width: 100%;
+        }
+        .crash-panel-toggle:focus { outline: 2px solid #ef5350; border-radius: 3px; }
+        .crash-count-badge {
+            background-color: #c62828; color: #fff;
+            font-size: 0.75em; padding: 2px 7px; border-radius: 10px;
+        }
+        .crash-entry {
+            background-color: #1e1212; border: 1px solid #4a2020;
+            border-radius: 4px; padding: 8px 12px; margin-bottom: 8px;
+            cursor: pointer; transition: background-color 0.15s;
+        }
+        .crash-entry:hover { background-color: #2d1a1a; }
+        .crash-entry:focus { outline: 2px solid #ef5350; outline-offset: 2px; }
+        .crash-entry-header { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+        .crash-label {
+            font-size: 0.68em; font-weight: 700; text-transform: uppercase;
+            padding: 1px 5px; border-radius: 3px; letter-spacing: 0.05em; flex-shrink: 0;
+        }
+        .crash-label-fatal  { background-color: #b71c1c; color: #fff; }
+        .crash-label-error  { background-color: #4a148c; color: #fff; }
+        .crash-label-ensure { background-color: #e65100; color: #fff; }
+        .crash-type { color: #4fc3f7; font-weight: bold; font-size: 0.85em; flex-shrink: 0; }
+        .crash-content-preview {
+            color: #ef9a9a; font-size: 0.85em;
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+            flex: 1; min-width: 0;
+        }
+        .crash-callstack {
+            color: #aaa; font-size: 0.78em; margin: 6px 0 0 0;
+            padding: 6px 8px; background-color: #160e0e; border-radius: 3px;
+            max-height: 200px; overflow-y: auto; white-space: pre;
+            font-family: 'Consolas', monospace;
+        }
+        .log-entry.crash-highlight {
+            background-color: #3a2020 !important;
+            outline: 2px solid #ef5350;
+            outline-offset: 1px;
         }
     </style>
 </head>
 <body>
-    <!-- Skip links for accessibility -->
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <a href="#logContent" class="skip-link">Skip to log entries</a>
-    
-    <!-- Live region for dynamic content announcements -->
     <div aria-live="polite" aria-atomic="true" class="sr-only" id="liveRegion"></div>
-    
+
     <div class="container" id="main-content">
-        <h1 class="mb-4">
-            Unreal Engine Log Analyzer
-        </h1>
-        
-        <!-- Navigation tabs -->
+        <h1 class="mb-4">Unreal Engine Log Analyzer</h1>
+
         <ul class="nav nav-tabs mb-4" id="mainTabs" role="tablist">
             <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="log-tab" data-bs-toggle="tab" data-bs-target="#log-panel" 
-                        type="button" role="tab" aria-controls="log-panel" aria-selected="true">
-                    Log Analyzer
-                </button>
+                <button class="nav-link active" id="log-tab" data-bs-toggle="tab" data-bs-target="#log-panel"
+                        type="button" role="tab" aria-controls="log-panel" aria-selected="true">Log Analyzer</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="memreport-tab" data-bs-toggle="tab" data-bs-target="#memreport-panel" 
-                        type="button" role="tab" aria-controls="memreport-panel" aria-selected="false">
-                    MemReport
-                </button>
+                <button class="nav-link" id="memreport-tab" data-bs-toggle="tab" data-bs-target="#memreport-panel"
+                        type="button" role="tab" aria-controls="memreport-panel" aria-selected="false">MemReport</button>
             </li>
         </ul>
-        
-        <!-- Tab content -->
+
         <div class="tab-content" id="mainTabContent">
             <!-- Log Analyzer Panel -->
             <div class="tab-pane fade show active" id="log-panel" role="tabpanel" aria-labelledby="log-tab">
                 <div class="upload-container">
-                    <!-- Input mode toggle -->
                     <ul class="nav nav-pills mb-3" id="inputModeTabs" role="tablist">
                         <li class="nav-item" role="presentation">
-                            <button class="nav-link active" id="upload-mode-tab" data-bs-toggle="pill" 
-                                    data-bs-target="#upload-mode" type="button" role="tab" 
+                            <button class="nav-link active" id="upload-mode-tab" data-bs-toggle="pill"
+                                    data-bs-target="#upload-mode" type="button" role="tab"
                                     aria-controls="upload-mode" aria-selected="true">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-cloud-upload me-1" viewBox="0 0 16 16">
                                     <path fill-rule="evenodd" d="M4.406 1.342A5.53 5.53 0 0 1 8 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 0 1 0-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 0 0-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.21 10 3.781 10H6a.5.5 0 0 1 0 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/>
@@ -373,8 +193,8 @@
                             </button>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <button class="nav-link" id="paste-mode-tab" data-bs-toggle="pill" 
-                                    data-bs-target="#paste-mode" type="button" role="tab" 
+                            <button class="nav-link" id="paste-mode-tab" data-bs-toggle="pill"
+                                    data-bs-target="#paste-mode" type="button" role="tab"
                                     aria-controls="paste-mode" aria-selected="false">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard-plus me-1" viewBox="0 0 16 16">
                                     <path fill-rule="evenodd" d="M8 7a.5.5 0 0 1 .5.5V9H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V10H6a.5.5 0 0 1 0-1h1.5V7.5A.5.5 0 0 1 8 7z"/>
@@ -387,47 +207,43 @@
                     </ul>
 
                     <div class="tab-content" id="inputModeContent">
-                        <!-- Upload File mode -->
                         <div class="tab-pane fade show active" id="upload-mode" role="tabpanel" aria-labelledby="upload-mode-tab">
-            <form id="uploadForm" class="mb-3" role="form" aria-label="Log file upload form">
-                <div class="mb-3">
-                    <label for="logFile" class="form-label">Upload Log File</label>
-                    <div class="drop-zone" id="dropZone" 
-                         role="button" 
-                         tabindex="0"
-                         aria-label="Drag and drop log files here or click to browse"
-                         aria-describedby="dropZoneHelp">
-                        <div class="drop-zone-content">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor" class="bi bi-cloud-upload mb-3" viewBox="0 0 16 16">
-                                <path fill-rule="evenodd" d="M4.406 1.342A5.53 5.53 0 0 1 8 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 0 1 0-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 0 0-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.21 10 3.781 10H6a.5.5 0 0 1 0 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/>
-                                <path fill-rule="evenodd" d="M7.646 4.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707V14.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3z"/>
-                            </svg>
-                            <p class="drop-zone-text">Drag and drop log files here</p>
-                            <p class="drop-zone-subtext">or click to browse</p>
-                        </div>
-                        <input type="file" class="form-control visually-hidden" id="logFile" accept=".log,.txt,.memreport" 
-                               aria-describedby="fileHelp" tabindex="-1">
-                    </div>
-                    <div id="dropZoneHelp" class="form-text">Select a .log, .txt, or .memreport file to analyze</div>
-                </div>
-                <button type="submit" class="btn btn-primary" id="uploadButton" 
-                        aria-label="Upload and analyze log file">Refresh</button>
-            </form>
+                            <form id="uploadForm" class="mb-3" role="form" aria-label="Log file upload form">
+                                <div class="mb-3">
+                                    <label for="logFile" class="form-label">Upload Log File</label>
+                                    <div class="drop-zone" id="dropZone" role="button" tabindex="0"
+                                         aria-label="Drag and drop log files here or click to browse"
+                                         aria-describedby="dropZoneHelp">
+                                        <div class="drop-zone-content">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" fill="currentColor" class="bi bi-cloud-upload mb-3" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd" d="M4.406 1.342A5.53 5.53 0 0 1 8 0c2.69 0 4.923 2 5.166 4.579C14.758 4.804 16 6.137 16 7.773 16 9.569 14.502 11 12.687 11H10a.5.5 0 0 1 0-1h2.688C13.979 10 15 8.988 15 7.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 2.825 10.328 1 8 1a4.53 4.53 0 0 0-2.941 1.1c-.757.652-1.153 1.438-1.153 2.055v.448l-.445.049C2.064 4.805 1 5.952 1 7.318 1 8.785 2.21 10 3.781 10H6a.5.5 0 0 1 0 1H3.781C1.708 11 0 9.366 0 7.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383z"/>
+                                                <path fill-rule="evenodd" d="M7.646 4.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707V14.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3z"/>
+                                            </svg>
+                                            <p class="drop-zone-text">Drag and drop log files here</p>
+                                            <p class="drop-zone-subtext">or click to browse</p>
+                                        </div>
+                                        <input type="file" class="form-control visually-hidden" id="logFile" accept=".log,.txt,.memreport"
+                                               aria-describedby="fileHelp" tabindex="-1">
+                                    </div>
+                                    <div id="dropZoneHelp" class="form-text">Select a .log, .txt, or .memreport file to analyze</div>
+                                </div>
+                                <button type="submit" class="btn btn-primary" id="uploadButton"
+                                        aria-label="Upload and analyze log file">Refresh</button>
+                            </form>
                         </div>
 
-                        <!-- Paste Log mode -->
                         <div class="tab-pane fade" id="paste-mode" role="tabpanel" aria-labelledby="paste-mode-tab">
                             <form id="pasteForm" class="mb-3" role="form" aria-label="Paste log text form">
                                 <div class="mb-3">
                                     <label for="pasteLogText" class="form-label">Paste Log Text</label>
-                                    <textarea class="form-control" id="pasteLogText" rows="8" 
+                                    <textarea class="form-control" id="pasteLogText" rows="8"
                                               placeholder="Paste your Unreal Engine log content here..."
                                               aria-describedby="pasteHelp"
-                                              style="font-family: 'Consolas', monospace; font-size: 0.85rem; resize: vertical;"></textarea>
-                                    <div id="pasteHelp" class="form-text">Paste log lines directly — no file needed</div>
+                                              style="font-family:'Consolas',monospace;font-size:0.85rem;resize:vertical;"></textarea>
+                                    <div id="pasteHelp" class="form-text">Paste log lines directly &mdash; no file needed</div>
                                 </div>
                                 <div class="d-flex gap-2">
-                                    <button type="submit" class="btn btn-primary" id="pasteAnalyzeButton" 
+                                    <button type="submit" class="btn btn-primary" id="pasteAnalyzeButton"
                                             aria-label="Analyze pasted log text">Analyze</button>
                                     <button type="button" class="btn btn-outline-secondary" id="pasteClearButton"
                                             aria-label="Clear pasted text">Clear</button>
@@ -435,137 +251,125 @@
                             </form>
                         </div>
                     </div>
-        </div>
+                </div>
 
-        <div class="filters-container" role="region" aria-label="Log filters">
-            <h5>
-                <a class="text-decoration-none" data-bs-toggle="collapse" href="#logTypeFiltersCollapse" 
-                   role="button" aria-expanded="true" aria-controls="logTypeFiltersCollapse"
-                   tabindex="0">
-                    Filter Log Types
-                    <span class="ms-2"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg></span>
-                </a>
-            </h5>
-            <div class="mb-3">
-                <label for="logSearchInput" class="visually-hidden">Search log content</label>
-                <div class="search-container">
-                    <div class="input-group">
-                        <input type="text" class="form-control" id="logSearchInput" 
-                               placeholder="Search log content..." 
-                               aria-label="Search log entries"
-                               tabindex="0">
-                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" 
-                                data-bs-toggle="dropdown" aria-expanded="false"
-                                aria-label="Search options">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-gear" viewBox="0 0 16 16">
-                                <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
-                                <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159zM8 5.754a2.246 2.246 0 1 1 0 4.492 2.246 2.246 0 0 1 0-4.492z"/>
+                <div class="filters-container" role="region" aria-label="Log filters">
+                    <h5>
+                        <a class="text-decoration-none" data-bs-toggle="collapse" href="#logTypeFiltersCollapse"
+                           role="button" aria-expanded="true" aria-controls="logTypeFiltersCollapse" tabindex="0">
+                            Filter Log Types
+                            <span class="ms-2"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg></span>
+                        </a>
+                    </h5>
+                    <div class="mb-3">
+                        <label for="logSearchInput" class="visually-hidden">Search log content</label>
+                        <div class="input-group">
+                            <input type="text" class="form-control" id="logSearchInput"
+                                   placeholder="Search log content..." aria-label="Search log entries" tabindex="0">
+                            <button class="btn btn-outline-secondary dropdown-toggle" type="button"
+                                    data-bs-toggle="dropdown" aria-expanded="false" aria-label="Search options">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-gear" viewBox="0 0 16 16">
+                                    <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
+                                    <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159zM8 5.754a2.246 2.246 0 1 1 0 4.492 2.246 2.246 0 0 1 0-4.492z"/>
+                                </svg>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end">
+                                <li><h6 class="dropdown-header">Search Options</h6></li>
+                                <li><hr class="dropdown-divider"></li>
+                                <li><label class="dropdown-item"><input type="checkbox" id="caseSensitive" class="form-check-input me-2"> Case sensitive</label></li>
+                                <li><label class="dropdown-item"><input type="checkbox" id="useRegex" class="form-check-input me-2"> Use regex</label></li>
+                                <li><hr class="dropdown-divider"></li>
+                                <li><h6 class="dropdown-header">Recent Searches</h6></li>
+                                <li><div id="searchHistory" class="dropdown-item-text small"></div></li>
+                                <li><hr class="dropdown-divider"></li>
+                                <li><button class="dropdown-item text-danger" id="clearHistory">Clear History</button></li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="collapse show" id="logTypeFiltersCollapse">
+                        <div class="mb-3" id="logLevelFilters" role="group" aria-label="Log level filters">
+                            <label class="form-check-label me-3">
+                                <input class="form-check-input me-1 log-level-filter" type="checkbox" value="Display" checked aria-label="Filter Display level logs">
+                                Display <span class="badge bg-secondary" id="count-Display">0</span>
+                            </label>
+                            <label class="form-check-label me-3">
+                                <input class="form-check-input me-1 log-level-filter" type="checkbox" value="Warning" checked aria-label="Filter Warning level logs">
+                                Warning <span class="badge bg-secondary" id="count-Warning">0</span>
+                            </label>
+                            <label class="form-check-label me-3">
+                                <input class="form-check-input me-1 log-level-filter" type="checkbox" value="Error" checked aria-label="Filter Error level logs">
+                                Error <span class="badge bg-secondary" id="count-Error">0</span>
+                            </label>
+                            <label class="form-check-label me-3 ms-3 border-start ps-3" style="border-color:#444 !important;">
+                                <input class="form-check-input me-1" type="checkbox" id="collapseDuplicates" aria-label="Collapse duplicate log entries">
+                                Collapse duplicates
+                            </label>
+                        </div>
+                        <div class="mb-2">
+                            <label class="form-check-label">
+                                <input class="form-check-input me-1" type="checkbox" id="multiSelect"
+                                       aria-label="Multi-select: show all level-eligible categories with accurate counts">
+                                Multi-select
+                            </label>
+                        </div>
+                        <div id="logTypeFilters" class="row" role="group" aria-label="Log type filters"></div>
+                    </div>
+                </div>
+
+                <!-- Crash Panel — auto-populated on load; hidden when no crashes detected -->
+                <div id="crashPanel" class="crash-panel-container" style="display:none;"
+                     role="region" aria-label="Crash and error summary">
+                    <h5 class="mb-0">
+                        <button class="crash-panel-toggle"
+                                data-bs-toggle="collapse" data-bs-target="#crashPanelBody"
+                                aria-expanded="true" aria-controls="crashPanelBody">
+                            &#9888; Crashes &amp; Critical Errors
+                            <span class="crash-count-badge" id="crashPanelBadge">0</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-chevron-down ms-auto" viewBox="0 0 16 16">
+                                <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
                             </svg>
                         </button>
-                        <ul class="dropdown-menu dropdown-menu-end">
-                            <li><h6 class="dropdown-header">Search Options</h6></li>
-                            <li><hr class="dropdown-divider"></li>
-                            <li>
-                                <label class="dropdown-item">
-                                    <input type="checkbox" id="caseSensitive" class="form-check-input me-2">
-                                    Case sensitive
-                                </label>
-                            </li>
-                            <li>
-                                <label class="dropdown-item">
-                                    <input type="checkbox" id="useRegex" class="form-check-input me-2">
-                                    Use regex
-                                </label>
-                            </li>
-                            <li><hr class="dropdown-divider"></li>
-                            <li><h6 class="dropdown-header">Recent Searches</h6></li>
-                            <li><div id="searchHistory" class="dropdown-item-text small"></div></li>
-                            <li><hr class="dropdown-divider"></li>
-                            <li><button class="dropdown-item text-danger" id="clearHistory">Clear History</button></li>
-                        </ul>
+                    </h5>
+                    <div class="collapse show" id="crashPanelBody">
+                        <div id="crashPanelList" class="mt-2"></div>
+                    </div>
+                </div>
+
+                <div class="log-container" id="logContent" role="log" aria-label="Log entries">
+                    <div class="export-buttons d-flex justify-content-end" style="gap:8px;">
+                        <button class="export-button" id="exportCsv" aria-label="Export as CSV" tabindex="0">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-spreadsheet" viewBox="0 0 16 16">
+                                <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 3A1.5 1.5 0 0 0 11 4.5h2V9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5v2z"/>
+                                <path d="M4.5 12a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7zm0-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7zm0-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7z"/>
+                            </svg>
+                            CSV
+                        </button>
+                        <button class="export-button" id="exportJson" aria-label="Export as JSON" tabindex="0">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-code" viewBox="0 0 16 16">
+                                <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5h-2z"/>
+                                <path d="M8.646 6.646a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1 0 .708l-2 2a.5.5 0 0 1-.708-.708L10.293 9H6a.5.5 0 0 1 0-1h4.293L8.646 6.354a.5.5 0 0 1 0-.708zm-1.292 0a.5.5 0 0 0-.708 0l-2 2a.5.5 0 0 0 0 .708l2 2a.5.5 0 0 0 .708-.708L5.707 9H10a.5.5 0 0 0 0-1H5.707l1.647-1.646z"/>
+                            </svg>
+                            JSON
+                        </button>
+                        <button class="copy-button" id="copyButton" aria-label="Copy filtered results to clipboard" tabindex="0">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard" viewBox="0 0 16 16">
+                                <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"/>
+                                <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/>
+                            </svg>
+                            Copy
+                        </button>
                     </div>
                 </div>
             </div>
-            <div class="collapse show" id="logTypeFiltersCollapse">
-                <div class="mb-3" id="logLevelFilters" role="group" aria-label="Log level filters">
-                    <label class="form-check-label me-3">
-                        <input class="form-check-input me-1 log-level-filter" type="checkbox" value="Display" checked
-                               aria-label="Filter Display level logs">
-                        Display <span class="badge bg-secondary" id="count-Display">0</span>
-                    </label>
-                    <label class="form-check-label me-3">
-                        <input class="form-check-input me-1 log-level-filter" type="checkbox" value="Warning" checked
-                               aria-label="Filter Warning level logs">
-                        Warning <span class="badge bg-secondary" id="count-Warning">0</span>
-                    </label>
-                    <label class="form-check-label me-3">
-                        <input class="form-check-input me-1 log-level-filter" type="checkbox" value="Error" checked
-                               aria-label="Filter Error level logs">
-                        Error <span class="badge bg-secondary" id="count-Error">0</span>
-                    </label>
-                    <label class="form-check-label me-3 ms-3 border-start ps-3" style="border-color: #444 !important;">
-                        <input class="form-check-input me-1" type="checkbox" id="collapseDuplicates"
-                               aria-label="Collapse duplicate log entries">
-                        Collapse duplicates
-                    </label>
-                </div>
-                <div class="mb-2">
-                    <label class="form-check-label">
-                        <input class="form-check-input me-1" type="checkbox" id="multiSelect"
-                               aria-label="Multi-select: show all level-eligible categories with accurate counts">
-                        Multi-select
-                    </label>
-                </div>
-                <div id="logTypeFilters" class="row" role="group" aria-label="Log type filters">
-                    <!-- Log type checkboxes will be added here dynamically -->
-                </div>
-            </div>
-        </div>
-
-        <div class="log-container" id="logContent" role="log" aria-label="Log entries">
-            <div class="export-buttons d-flex justify-content-end" style="gap: 8px;">
-                <button class="export-button" id="exportCsv" 
-                        aria-label="Export as CSV"
-                        tabindex="0">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-spreadsheet" viewBox="0 0 16 16">
-                        <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 3A1.5 1.5 0 0 0 11 4.5h2V9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5v2z"/>
-                        <path d="M4.5 12a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7zm0-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7zm0-2a.5.5 0 0 1 0-1h7a.5.5 0 0 1 0 1h-7z"/>
-                    </svg>
-                    CSV
-                </button>
-                <button class="export-button" id="exportJson" 
-                        aria-label="Export as JSON"
-                        tabindex="0">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-code" viewBox="0 0 16 16">
-                        <path d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5h-2z"/>
-                        <path d="M8.646 6.646a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1 0 .708l-2 2a.5.5 0 0 1-.708-.708L10.293 9H6a.5.5 0 0 1 0-1h4.293L8.646 6.354a.5.5 0 0 1 0-.708zm-1.292 0a.5.5 0 0 0-.708 0l-2 2a.5.5 0 0 0 0 .708l2 2a.5.5 0 0 0 .708-.708L5.707 9H10a.5.5 0 0 0 0-1H5.707l1.647-1.646z"/>
-                    </svg>
-                    JSON
-                </button>
-                <button class="copy-button" id="copyButton" 
-                        aria-label="Copy filtered results to clipboard"
-                        tabindex="0">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard" viewBox="0 0 16 16">
-                        <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"/>
-                        <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/>
-                    </svg>
-                    Copy
-                </button>
-            </div>
-            <!-- Log entries will be displayed here -->
-        </div>
-            </div>
             <!-- End Log Analyzer Panel -->
-            
+
             <!-- MemReport Analyzer Panel -->
             <div class="tab-pane fade" id="memreport-panel" role="tabpanel" aria-labelledby="memreport-tab">
                 <div class="upload-container">
                     <form id="memreportUploadForm" class="mb-3" role="form" aria-label="MemReport file upload form">
                         <div class="mb-3">
                             <label for="memreportFile" class="form-label">Upload MemReport File</label>
-                            <div class="drop-zone" id="memreportDropZone" 
-                                 role="button" 
-                                 tabindex="0"
+                            <div class="drop-zone" id="memreportDropZone" role="button" tabindex="0"
                                  aria-label="Drag and drop memreport files here or click to browse"
                                  aria-describedby="memreportDropZoneHelp">
                                 <div class="drop-zone-content">
@@ -576,52 +380,35 @@
                                     <p class="drop-zone-text">Drag and drop memreport files here</p>
                                     <p class="drop-zone-subtext">or click to browse</p>
                                 </div>
-                                <input type="file" class="form-control visually-hidden" id="memreportFile" accept=".memreport,.txt" 
+                                <input type="file" class="form-control visually-hidden" id="memreportFile" accept=".memreport,.txt"
                                        aria-describedby="memreportFileHelp" tabindex="-1">
                             </div>
                             <div id="memreportDropZoneHelp" class="form-text">Select a .memreport or .txt file to analyze</div>
                         </div>
-                        <button type="submit" class="btn btn-primary" id="memreportUploadButton" 
+                        <button type="submit" class="btn btn-primary" id="memreportUploadButton"
                                 aria-label="Upload and analyze memreport file">Analyze MemReport</button>
                     </form>
                 </div>
-
-                <!-- MemReport content container with same styling as log container -->
-                <div class="log-container" id="memreportContent" role="main" aria-label="MemReport analysis results">
-                    <!-- MemReport sections will be displayed here -->
-                </div>
+                <div class="log-container" id="memreportContent" role="main" aria-label="MemReport analysis results"></div>
             </div>
             <!-- End MemReport Analyzer Panel -->
         </div>
     </div>
-    
-    <!-- Toast container for notifications -->
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1050;">
-        <!-- Toasts will be dynamically added here -->
-    </div>
-    
-    <!-- Copy success toast -->
+
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index:1050;"></div>
     <div class="toast" id="copyToast" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="toast-header">
             <strong class="me-auto text-success">Success</strong>
             <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
-        <div class="toast-body">
-            Copied to clipboard!
-        </div>
+        <div class="toast-body">Copied to clipboard!</div>
     </div>
 
-    <!-- Footer -->
     <footer class="footer mt-auto py-3 bg-dark text-light text-center">
         <div class="container">
-            <p class="mb-0">
-                This project is open source and available under the 
-                <a href="https://github.com/AugustWasilowski/unreal-log-analyzer" 
-                   target="_blank" 
-                   rel="noopener noreferrer" 
-                   class="text-light text-decoration-underline">
-                    MIT License
-                </a>
+            <p class="mb-0">This project is open source and available under the
+                <a href="https://github.com/AugustWasilowski/unreal-log-analyzer"
+                   target="_blank" rel="noopener noreferrer" class="text-light text-decoration-underline">MIT License</a>
             </p>
         </div>
     </footer>
@@ -630,10 +417,10 @@
     <script src="/static/js/state.js?v=1.3"></script>
     <script src="/static/js/utils.js?v=1.3"></script>
     <script src="/static/js/log-parser.js?v=1.5"></script>
-    <script src="/static/js/ui.js?v=1.5"></script>
+    <script src="/static/js/ui.js?v=1.6"></script>
     <script src="/static/js/memreport-parser.js?v=1.3"></script>
     <script src="/static/js/memreport-charts.js?v=1.3"></script>
     <script src="/static/js/memreport-page.js?v=1.3"></script>
-    <script src="/static/js/app.js?v=1.5"></script>
+    <script src="/static/js/app.js?v=1.7"></script>
 </body>
 </html>


### PR DESCRIPTION
## Task 2.1 — Crash-first view panel

Auto-surfaces Fatal/Ensure/Assert/critical-Error entries above the main log list so the most important information is visible immediately on load.

### What's in this PR

**`static/js/app.js` (v1.7)**
- `isCrashEntry(entry)` — detects Fatal/Ensure/Assertion/critical-Error
- `renderCrashPanel(allEntries)` — builds the collapsible crash panel DOM
- `scrollToCrashEntry(entry)` — clears filters if needed, then scrolls + highlights the entry in the main log
- `updateDisplay()` now calls `renderCrashPanel` on every render

**`static/js/ui.js` (v1.6)**
- Adds `div.dataset.crashKey` to every rendered log entry for scroll targeting
- `contentSpan.style.whiteSpace = 'pre-wrap'` for callstack rendering

**`templates/index.html`**
- Crash panel CSS (`.crash-panel-container`, `.crash-entry`, label variants, `.crash-callstack`, `.crash-highlight` pulse animation)
- Crash panel HTML — collapsible Bootstrap 5 section between filters and log list
- Bumped script versions to v1.6/v1.7

### Behaviour
- Panel hidden when no crashes detected
- Shows entry type badge, first line of content, and collapsed callstack (≤50 lines)
- Click any crash entry → scrolls to it in main log, highlights with a brief pulse
- If entry is currently filtered out, filters are cleared first before scrolling